### PR TITLE
Malcohol/fewer dynamic casts

### DIFF
--- a/BabelWiresPlugins/Smf/Plugin/smfFormat.cpp
+++ b/BabelWiresPlugins/Smf/Plugin/smfFormat.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<babelwires::FileFeature> smf::SmfFormat0TargetFormat::createNewF
 
 void smf::SmfFormat0TargetFormat::writeToFile(const babelwires::FileFeature& sequence, std::ostream& os,
                                  babelwires::UserLogger& userLogger) const {
-    writeToSmfFormat0(os, *sequence.asA<target::Format0SmfFeature>());
+    writeToSmfFormat0(os, *sequence.as<target::Format0SmfFeature>());
 }
 
 smf::SmfFormat1TargetFormat::SmfFormat1TargetFormat()
@@ -74,5 +74,5 @@ std::unique_ptr<babelwires::FileFeature> smf::SmfFormat1TargetFormat::createNewF
 
 void smf::SmfFormat1TargetFormat::writeToFile(const babelwires::FileFeature& sequence, std::ostream& os,
                                  babelwires::UserLogger& userLogger) const {
-    writeToSmfFormat1(os, *sequence.asA<target::Format1SmfFeature>());
+    writeToSmfFormat1(os, *sequence.as<target::Format1SmfFeature>());
 }

--- a/BabelWiresPlugins/Smf/Plugin/smfFormat.cpp
+++ b/BabelWiresPlugins/Smf/Plugin/smfFormat.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<babelwires::FileFeature> smf::SmfFormat0TargetFormat::createNewF
 
 void smf::SmfFormat0TargetFormat::writeToFile(const babelwires::FileFeature& sequence, std::ostream& os,
                                  babelwires::UserLogger& userLogger) const {
-    writeToSmfFormat0(os, dynamic_cast<const target::Format0SmfFeature&>(sequence));
+    writeToSmfFormat0(os, *sequence.asA<target::Format0SmfFeature>());
 }
 
 smf::SmfFormat1TargetFormat::SmfFormat1TargetFormat()
@@ -74,5 +74,5 @@ std::unique_ptr<babelwires::FileFeature> smf::SmfFormat1TargetFormat::createNewF
 
 void smf::SmfFormat1TargetFormat::writeToFile(const babelwires::FileFeature& sequence, std::ostream& os,
                                  babelwires::UserLogger& userLogger) const {
-    writeToSmfFormat1(os, dynamic_cast<const target::Format1SmfFeature&>(sequence));
+    writeToSmfFormat1(os, *sequence.asA<target::Format1SmfFeature>());
 }

--- a/BabelWiresPlugins/Smf/Plugin/smfSourceModel.cpp
+++ b/BabelWiresPlugins/Smf/Plugin/smfSourceModel.cpp
@@ -135,11 +135,11 @@ int smf::source::Format1SmfFeature::getNumMidiTracks() const {
 }
 
 const smf::source::ChannelGroup& smf::source::Format1SmfFeature::getMidiTrack(int i) const {
-    return dynamic_cast<const ChannelGroup&>(*m_tracks->getFeature(i));
+    return *m_tracks->getFeature(i)->asA<ExtensibleChannelGroup>();
 }
 
 smf::source::ChannelGroup* smf::source::Format1SmfFeature::addMidiTrack() {
-    return dynamic_cast<ChannelGroup*>(m_tracks->addEntry());
+    return m_tracks->addEntry()->asA<ExtensibleChannelGroup>();
 }
 
 std::unique_ptr<babelwires::Feature> smf::source::TrackArray::createNextEntry() const {

--- a/BabelWiresPlugins/Smf/Plugin/smfSourceModel.cpp
+++ b/BabelWiresPlugins/Smf/Plugin/smfSourceModel.cpp
@@ -135,11 +135,11 @@ int smf::source::Format1SmfFeature::getNumMidiTracks() const {
 }
 
 const smf::source::ChannelGroup& smf::source::Format1SmfFeature::getMidiTrack(int i) const {
-    return *m_tracks->getFeature(i)->asA<ExtensibleChannelGroup>();
+    return *m_tracks->getFeature(i)->as<ExtensibleChannelGroup>();
 }
 
 smf::source::ChannelGroup* smf::source::Format1SmfFeature::addMidiTrack() {
-    return m_tracks->addEntry()->asA<ExtensibleChannelGroup>();
+    return m_tracks->addEntry()->as<ExtensibleChannelGroup>();
 }
 
 std::unique_ptr<babelwires::Feature> smf::source::TrackArray::createNextEntry() const {

--- a/BabelWiresPlugins/Smf/Plugin/smfWriter.cpp
+++ b/BabelWiresPlugins/Smf/Plugin/smfWriter.cpp
@@ -116,11 +116,11 @@ void smf::SmfWriter::writeNoteEvent(int channel, seqwires::ModelDuration timeSin
     assert(channel <= 15);
 
     writeModelDuration(timeSinceLastEvent);
-    if (const seqwires::NoteOnEvent* noteOn = e.asA<seqwires::NoteOnEvent>()) {
+    if (const seqwires::NoteOnEvent* noteOn = e.as<seqwires::NoteOnEvent>()) {
         m_os->put(0b10010000 | channel);
         m_os->put(noteOn->m_pitch);
         m_os->put(noteOn->m_velocity);
-    } else if (const seqwires::NoteOffEvent* noteOff = e.asA<seqwires::NoteOffEvent>()) {
+    } else if (const seqwires::NoteOffEvent* noteOff = e.as<seqwires::NoteOffEvent>()) {
         m_os->put(0b10000000 | channel);
         m_os->put(noteOff->m_pitch);
         m_os->put(noteOff->m_velocity);
@@ -134,9 +134,9 @@ namespace {
 
     /// Only noteOn and noteOff events are understood.
     bool noteOnOffFilter(const seqwires::TrackEvent& event) {
-        if (event.asA<seqwires::NoteOnEvent>()) {
+        if (event.as<seqwires::NoteOnEvent>()) {
             return true;
-        } else if (event.asA<seqwires::NoteOffEvent>()) {
+        } else if (event.as<seqwires::NoteOffEvent>()) {
             return true;
         } else {
             return false;

--- a/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
+++ b/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
@@ -25,18 +25,18 @@ TEST(SmfSaveLoadTest, cMajorScale) {
         smf::target::Format0SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).as<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         EXPECT_EQ(tracks->getNumFeatures(), 1);
 
-        auto* channelTrack = tracks->getFeature(0)->asA<babelwires::RecordFeature>();
+        auto* channelTrack = tracks->getFeature(0)->as<babelwires::RecordFeature>();
         ASSERT_NE(channelTrack, nullptr);
         EXPECT_EQ(channelTrack->getNumFeatures(), 2);
 
-        auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
+        auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).as<babelwires::IntFeature>();
         channelFeature->set(2);
 
-        auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
+        auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).as<seqwires::TrackFeature>();
 
         auto track = std::make_unique<seqwires::Track>();
 
@@ -53,13 +53,13 @@ TEST(SmfSaveLoadTest, cMajorScale) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+        auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
         const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
         EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-        const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
+        const auto* trackFeature = channelGroup.getFeature(0)->as<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch2")));
 
@@ -76,7 +76,7 @@ namespace {
     };
 
     void addMetadata(smf::target::SmfFeature& smfFeature, std::uint8_t flags) {
-        auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).asA<smf::MidiMetadata>();
+        auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).as<smf::MidiMetadata>();
         if (flags & HAS_SEQUENCE_NAME) {
             metadata->getActivatedSequenceName().set("Test Sequence Name");
         }
@@ -89,7 +89,7 @@ namespace {
     }
 
     void checkMetadata(const smf::source::SmfFeature& smfFeature, std::uint8_t flags) {
-        const auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).asA<smf::MidiMetadata>();
+        const auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).as<smf::MidiMetadata>();
         if (flags & HAS_SEQUENCE_NAME) {
             ASSERT_NE(metadata->getSequenceName(), nullptr);
             EXPECT_EQ(metadata->getSequenceName()->get(), "Test Sequence Name");
@@ -118,18 +118,18 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
 
             addMetadata(smfFeature, metadata);
 
-            auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
+            auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).as<babelwires::ArrayFeature>();
             ASSERT_NE(tracks, nullptr);
             EXPECT_EQ(tracks->getNumFeatures(), 1);
 
-            auto* channelTrack = tracks->getFeature(0)->asA<babelwires::RecordFeature>();
+            auto* channelTrack = tracks->getFeature(0)->as<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
 
-            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).as<babelwires::IntFeature>();
             channelFeature->set(2);
 
-            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).as<seqwires::TrackFeature>();
 
             auto track = std::make_unique<seqwires::Track>();
 
@@ -145,7 +145,7 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+        auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         checkMetadata(*smfFeature, metadata);
@@ -153,7 +153,7 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
         const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
         EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-        const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
+        const auto* trackFeature = channelGroup.getFeature(0)->as<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch2")));
 
@@ -175,19 +175,19 @@ TEST(SmfSaveLoadTest, format0Chords) {
         smf::target::Format0SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).as<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         tracks->addEntry();
         tracks->addEntry();
         EXPECT_EQ(tracks->getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            auto* channelTrack = tracks->getFeature(i)->asA<babelwires::RecordFeature>();
+            auto* channelTrack = tracks->getFeature(i)->as<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
-            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).as<babelwires::IntFeature>();
             channelFeature->set(i);
-            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).as<seqwires::TrackFeature>();
             auto track = std::make_unique<seqwires::Track>();
             testUtils::addSimpleNotes(chordPitches[i], *track);
             trackFeature->set(std::move(track));
@@ -202,7 +202,7 @@ TEST(SmfSaveLoadTest, format0Chords) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+        auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
@@ -210,7 +210,7 @@ TEST(SmfSaveLoadTest, format0Chords) {
         EXPECT_EQ(channelGroup.getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            const auto* trackFeature = channelGroup.getFeature(i)->asA<const seqwires::TrackFeature>();
+            const auto* trackFeature = channelGroup.getFeature(i)->as<const seqwires::TrackFeature>();
             ASSERT_NE(trackFeature, nullptr);
             ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier(trackName[i])));
             testUtils::testSimpleNotes(chordPitches[i], trackFeature->get());
@@ -228,19 +228,19 @@ TEST(SmfSaveLoadTest, format1Chords) {
         smf::target::Format1SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).as<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         tracks->addEntry();
         tracks->addEntry();
         EXPECT_EQ(tracks->getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            auto* channelTrack = tracks->getFeature(i)->asA<babelwires::RecordFeature>();
+            auto* channelTrack = tracks->getFeature(i)->as<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
-            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).as<babelwires::IntFeature>();
             channelFeature->set(i);
-            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).as<seqwires::TrackFeature>();
             auto track = std::make_unique<seqwires::Track>();
             testUtils::addSimpleNotes(chordPitches[i], *track);
             trackFeature->set(std::move(track));
@@ -255,17 +255,17 @@ TEST(SmfSaveLoadTest, format1Chords) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
+        auto smfFeature = feature.get()->as<const smf::source::Format1SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 3);
         for (int i = 0; i < 3; ++i) {
             const auto& channelGroup = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
             EXPECT_EQ(channelGroup.getNumFeatures(), 2);
-            const auto* channelFeature = channelGroup.getChildFromStep(babelwires::PathStep("ChanNo")).asA<const babelwires::IntFeature>();
+            const auto* channelFeature = channelGroup.getChildFromStep(babelwires::PathStep("ChanNo")).as<const babelwires::IntFeature>();
             ASSERT_NE(channelFeature, nullptr);
             EXPECT_EQ(channelFeature->get(), i);
-            const auto* trackFeature = channelGroup.getChildFromStep(babelwires::PathStep("Track")).asA<const seqwires::TrackFeature>();
+            const auto* trackFeature = channelGroup.getChildFromStep(babelwires::PathStep("Track")).as<const seqwires::TrackFeature>();
             ASSERT_NE(trackFeature, nullptr);
             testUtils::testSimpleNotes(chordPitches[i], trackFeature->get());
         }

--- a/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
+++ b/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
@@ -25,18 +25,18 @@ TEST(SmfSaveLoadTest, cMajorScale) {
         smf::target::Format0SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = dynamic_cast<babelwires::ArrayFeature*>(&smfFeature.getChildFromStep(babelwires::PathStep("tracks")));
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         EXPECT_EQ(tracks->getNumFeatures(), 1);
 
-        auto* channelTrack = dynamic_cast<babelwires::RecordFeature*>(tracks->getFeature(0));
+        auto* channelTrack = tracks->getFeature(0)->asA<babelwires::RecordFeature>();
         ASSERT_NE(channelTrack, nullptr);
         EXPECT_EQ(channelTrack->getNumFeatures(), 2);
 
-        auto* channelFeature = dynamic_cast<babelwires::IntFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Chan")));
+        auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
         channelFeature->set(2);
 
-        auto* trackFeature = dynamic_cast<seqwires::TrackFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Track")));
+        auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
 
         auto track = std::make_unique<seqwires::Track>();
 
@@ -53,13 +53,13 @@ TEST(SmfSaveLoadTest, cMajorScale) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
         const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
         EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-        const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(0));
+        const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch2")));
 
@@ -118,18 +118,18 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
 
             addMetadata(smfFeature, metadata);
 
-            auto* tracks = dynamic_cast<babelwires::ArrayFeature*>(&smfFeature.getChildFromStep(babelwires::PathStep("tracks")));
+            auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
             ASSERT_NE(tracks, nullptr);
             EXPECT_EQ(tracks->getNumFeatures(), 1);
 
-            auto* channelTrack = dynamic_cast<babelwires::RecordFeature*>(tracks->getFeature(0));
+            auto* channelTrack = tracks->getFeature(0)->asA<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
 
-            auto* channelFeature = dynamic_cast<babelwires::IntFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Chan")));
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
             channelFeature->set(2);
 
-            auto* trackFeature = dynamic_cast<seqwires::TrackFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Track")));
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
 
             auto track = std::make_unique<seqwires::Track>();
 
@@ -145,7 +145,7 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         checkMetadata(*smfFeature, metadata);
@@ -153,7 +153,7 @@ TEST(SmfSaveLoadTest, cMajorScaleWithMetadata) {
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
         const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
         EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-        const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(0));
+        const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch2")));
 
@@ -175,19 +175,19 @@ TEST(SmfSaveLoadTest, format0Chords) {
         smf::target::Format0SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = dynamic_cast<babelwires::ArrayFeature*>(&smfFeature.getChildFromStep(babelwires::PathStep("tracks")));
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         tracks->addEntry();
         tracks->addEntry();
         EXPECT_EQ(tracks->getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            auto* channelTrack = dynamic_cast<babelwires::RecordFeature*>(tracks->getFeature(i));
+            auto* channelTrack = tracks->getFeature(i)->asA<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
-            auto* channelFeature = dynamic_cast<babelwires::IntFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Chan")));
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
             channelFeature->set(i);
-            auto* trackFeature = dynamic_cast<seqwires::TrackFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Track")));
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
             auto track = std::make_unique<seqwires::Track>();
             testUtils::addSimpleNotes(chordPitches[i], *track);
             trackFeature->set(std::move(track));
@@ -202,7 +202,7 @@ TEST(SmfSaveLoadTest, format0Chords) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+        auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
@@ -210,7 +210,7 @@ TEST(SmfSaveLoadTest, format0Chords) {
         EXPECT_EQ(channelGroup.getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(i));
+            const auto* trackFeature = channelGroup.getFeature(i)->asA<const seqwires::TrackFeature>();
             ASSERT_NE(trackFeature, nullptr);
             ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier(trackName[i])));
             testUtils::testSimpleNotes(chordPitches[i], trackFeature->get());
@@ -228,19 +228,19 @@ TEST(SmfSaveLoadTest, format1Chords) {
         smf::target::Format1SmfFeature smfFeature;
         smfFeature.setToDefault();
 
-        auto* tracks = dynamic_cast<babelwires::ArrayFeature*>(&smfFeature.getChildFromStep(babelwires::PathStep("tracks")));
+        auto* tracks = smfFeature.getChildFromStep(babelwires::PathStep("tracks")).asA<babelwires::ArrayFeature>();
         ASSERT_NE(tracks, nullptr);
         tracks->addEntry();
         tracks->addEntry();
         EXPECT_EQ(tracks->getNumFeatures(), 3);
 
         for (int i = 0; i < 3; ++i) {
-            auto* channelTrack = dynamic_cast<babelwires::RecordFeature*>(tracks->getFeature(i));
+            auto* channelTrack = tracks->getFeature(i)->asA<babelwires::RecordFeature>();
             ASSERT_NE(channelTrack, nullptr);
             EXPECT_EQ(channelTrack->getNumFeatures(), 2);
-            auto* channelFeature = dynamic_cast<babelwires::IntFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Chan")));
+            auto* channelFeature = channelTrack->getChildFromStep(babelwires::PathStep("Chan")).asA<babelwires::IntFeature>();
             channelFeature->set(i);
-            auto* trackFeature = dynamic_cast<seqwires::TrackFeature*>(&channelTrack->getChildFromStep(babelwires::PathStep("Track")));
+            auto* trackFeature = channelTrack->getChildFromStep(babelwires::PathStep("Track")).asA<seqwires::TrackFeature>();
             auto track = std::make_unique<seqwires::Track>();
             testUtils::addSimpleNotes(chordPitches[i], *track);
             trackFeature->set(std::move(track));
@@ -255,17 +255,17 @@ TEST(SmfSaveLoadTest, format1Chords) {
 
         const auto feature = smf::parseSmfSequence(midiFile, log);
         ASSERT_NE(feature, nullptr);
-        auto smfFeature = dynamic_cast<const smf::source::Format1SmfFeature*>(feature.get());
+        auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
         ASSERT_NE(smfFeature, nullptr);
 
         EXPECT_EQ(smfFeature->getNumMidiTracks(), 3);
         for (int i = 0; i < 3; ++i) {
             const auto& channelGroup = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
             EXPECT_EQ(channelGroup.getNumFeatures(), 2);
-            const auto* channelFeature = dynamic_cast<const babelwires::IntFeature*>(&channelGroup.getChildFromStep(babelwires::PathStep("ChanNo")));
+            const auto* channelFeature = channelGroup.getChildFromStep(babelwires::PathStep("ChanNo")).asA<const babelwires::IntFeature>();
             ASSERT_NE(channelFeature, nullptr);
             EXPECT_EQ(channelFeature->get(), i);
-            const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(&channelGroup.getChildFromStep(babelwires::PathStep("Track")));
+            const auto* trackFeature = channelGroup.getChildFromStep(babelwires::PathStep("Track")).asA<const seqwires::TrackFeature>();
             ASSERT_NE(trackFeature, nullptr);
             testUtils::testSimpleNotes(chordPitches[i], trackFeature->get());
         }

--- a/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
+++ b/BabelWiresPlugins/Smf/Tests/saveLoadTests.cpp
@@ -76,7 +76,7 @@ namespace {
     };
 
     void addMetadata(smf::target::SmfFeature& smfFeature, std::uint8_t flags) {
-        auto* metadata = dynamic_cast<smf::MidiMetadata*>(&smfFeature.getChildFromStep(babelwires::PathStep("Meta")));
+        auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).asA<smf::MidiMetadata>();
         if (flags & HAS_SEQUENCE_NAME) {
             metadata->getActivatedSequenceName().set("Test Sequence Name");
         }
@@ -89,7 +89,7 @@ namespace {
     }
 
     void checkMetadata(const smf::source::SmfFeature& smfFeature, std::uint8_t flags) {
-        const auto* metadata = dynamic_cast<const smf::MidiMetadata*>(&smfFeature.getChildFromStep(babelwires::PathStep("Meta")));
+        const auto* metadata = smfFeature.getChildFromStep(babelwires::PathStep("Meta")).asA<smf::MidiMetadata>();
         if (flags & HAS_SEQUENCE_NAME) {
             ASSERT_NE(metadata->getSequenceName(), nullptr);
             EXPECT_EQ(metadata->getSequenceName()->get(), "Test Sequence Name");

--- a/BabelWiresPlugins/Smf/Tests/testSuiteTests.cpp
+++ b/BabelWiresPlugins/Smf/Tests/testSuiteTests.cpp
@@ -44,7 +44,7 @@ TEST(SmfTestSuiteTest, cMajorScale) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -56,7 +56,7 @@ TEST(SmfTestSuiteTest, cMajorScale) {
     EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
     const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-    const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(0));
+    const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature, nullptr);
     ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch0")));
 
@@ -76,7 +76,7 @@ TEST(SmfTestSuiteTest, multichannelChords0) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -90,7 +90,7 @@ TEST(SmfTestSuiteTest, multichannelChords0) {
     const seqwires::Track* tracks[3] = {};
 
     for (int i = 0; i < 3; ++i) {
-        const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(i));
+        const auto* trackFeature = channelGroup.getFeature(i)->asA<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier(channelNames[i])));
@@ -109,7 +109,7 @@ TEST(SmfTestSuiteTest, multichannelChords1) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format1SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -125,13 +125,13 @@ TEST(SmfTestSuiteTest, multichannelChords1) {
             dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
         EXPECT_EQ(channelGroup.getNumFeatures(), 2);
 
-        const auto* channelNumFeature = dynamic_cast<const babelwires::IntFeature*>(channelGroup.getFeature(0));
+        const auto* channelNumFeature = channelGroup.getFeature(0)->asA<const babelwires::IntFeature>();
         ASSERT_NE(channelNumFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(channelNumFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
         EXPECT_EQ(channelNumFeature->get(), i);
 
-        const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(1));
+        const auto* trackFeature = channelGroup.getFeature(1)->asA<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("Track")));
@@ -150,7 +150,7 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format1SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -164,18 +164,18 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
     const auto& channelGroup0 = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup0.getNumFeatures(), 3);
 
-    const auto* channelNumFeature = dynamic_cast<const babelwires::IntFeature*>(channelGroup0.getFeature(0));
+    const auto* channelNumFeature = channelGroup0.getFeature(0)->asA<const babelwires::IntFeature>();
     ASSERT_NE(channelNumFeature, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(channelNumFeature),
               babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
     EXPECT_EQ(channelNumFeature->get(), 0);
 
-    const auto* trackFeature0 = dynamic_cast<const seqwires::TrackFeature*>(channelGroup0.getFeature(1));
+    const auto* trackFeature0 = channelGroup0.getFeature(1)->asA<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature0, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(trackFeature0), babelwires::PathStep(babelwires::FieldIdentifier("Track")));
     tracks[0] = &trackFeature0->get();
 
-    const auto* trackFeature1 = dynamic_cast<const seqwires::TrackFeature*>(channelGroup0.getFeature(2));
+    const auto* trackFeature1 = channelGroup0.getFeature(2)->asA<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature1, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(trackFeature1), babelwires::PathStep(babelwires::FieldIdentifier("ex1")));
     tracks[1] = &trackFeature1->get();
@@ -183,13 +183,13 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
     const auto& channelGroup1 = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(1));
     EXPECT_EQ(channelGroup1.getNumFeatures(), 2);
 
-    const auto* channelNumFeature2 = dynamic_cast<const babelwires::IntFeature*>(channelGroup1.getFeature(0));
+    const auto* channelNumFeature2 = channelGroup1.getFeature(0)->asA<const babelwires::IntFeature>();
     ASSERT_NE(channelNumFeature2, nullptr);
     ASSERT_EQ(channelGroup1.getStepToChild(channelNumFeature2),
               babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
     EXPECT_EQ(channelNumFeature2->get(), 2);
 
-    const auto* trackFeature2 = dynamic_cast<const seqwires::TrackFeature*>(channelGroup1.getFeature(1));
+    const auto* trackFeature2 = channelGroup1.getFeature(1)->asA<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature2, nullptr);
     ASSERT_EQ(channelGroup1.getStepToChild(trackFeature2), babelwires::PathStep(babelwires::FieldIdentifier("Track")));
     tracks[2] = &trackFeature2->get();
@@ -206,7 +206,7 @@ TEST(SmfTestSuiteTest, multichannelChords3) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format1SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -224,13 +224,13 @@ TEST(SmfTestSuiteTest, multichannelChords3) {
             dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
         EXPECT_EQ(channelGroup.getNumFeatures(), 2);
 
-        const auto* channelNumFeature = dynamic_cast<const babelwires::IntFeature*>(channelGroup.getFeature(0));
+        const auto* channelNumFeature = channelGroup.getFeature(0)->asA<const babelwires::IntFeature>();
         ASSERT_NE(channelNumFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(channelNumFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
         EXPECT_EQ(channelNumFeature->get(), expectedChannelMapping[i]);
 
-        const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(1));
+        const auto* trackFeature = channelGroup.getFeature(1)->asA<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("Track")));
@@ -249,13 +249,13 @@ TEST(SmfTestSuiteTest, trackLength) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format0SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
     const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-    const auto* trackFeature = dynamic_cast<const seqwires::TrackFeature*>(channelGroup.getFeature(0));
+    const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature, nullptr);
 
     const seqwires::Track& track = trackFeature->get();
@@ -269,7 +269,7 @@ TEST(SmfTestSuiteTest, tempoTest) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = dynamic_cast<const smf::source::Format1SmfFeature*>(feature.get());
+    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();

--- a/BabelWiresPlugins/Smf/Tests/testSuiteTests.cpp
+++ b/BabelWiresPlugins/Smf/Tests/testSuiteTests.cpp
@@ -44,7 +44,7 @@ TEST(SmfTestSuiteTest, cMajorScale) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -56,7 +56,7 @@ TEST(SmfTestSuiteTest, cMajorScale) {
     EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
     const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-    const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
+    const auto* trackFeature = channelGroup.getFeature(0)->as<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature, nullptr);
     ASSERT_EQ(channelGroup.getStepToChild(trackFeature), babelwires::PathStep(babelwires::FieldIdentifier("ch0")));
 
@@ -76,7 +76,7 @@ TEST(SmfTestSuiteTest, multichannelChords0) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -90,7 +90,7 @@ TEST(SmfTestSuiteTest, multichannelChords0) {
     const seqwires::Track* tracks[3] = {};
 
     for (int i = 0; i < 3; ++i) {
-        const auto* trackFeature = channelGroup.getFeature(i)->asA<const seqwires::TrackFeature>();
+        const auto* trackFeature = channelGroup.getFeature(i)->as<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier(channelNames[i])));
@@ -109,7 +109,7 @@ TEST(SmfTestSuiteTest, multichannelChords1) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -125,13 +125,13 @@ TEST(SmfTestSuiteTest, multichannelChords1) {
             dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
         EXPECT_EQ(channelGroup.getNumFeatures(), 2);
 
-        const auto* channelNumFeature = channelGroup.getFeature(0)->asA<const babelwires::IntFeature>();
+        const auto* channelNumFeature = channelGroup.getFeature(0)->as<const babelwires::IntFeature>();
         ASSERT_NE(channelNumFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(channelNumFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
         EXPECT_EQ(channelNumFeature->get(), i);
 
-        const auto* trackFeature = channelGroup.getFeature(1)->asA<const seqwires::TrackFeature>();
+        const auto* trackFeature = channelGroup.getFeature(1)->as<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("Track")));
@@ -150,7 +150,7 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -164,18 +164,18 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
     const auto& channelGroup0 = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup0.getNumFeatures(), 3);
 
-    const auto* channelNumFeature = channelGroup0.getFeature(0)->asA<const babelwires::IntFeature>();
+    const auto* channelNumFeature = channelGroup0.getFeature(0)->as<const babelwires::IntFeature>();
     ASSERT_NE(channelNumFeature, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(channelNumFeature),
               babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
     EXPECT_EQ(channelNumFeature->get(), 0);
 
-    const auto* trackFeature0 = channelGroup0.getFeature(1)->asA<const seqwires::TrackFeature>();
+    const auto* trackFeature0 = channelGroup0.getFeature(1)->as<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature0, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(trackFeature0), babelwires::PathStep(babelwires::FieldIdentifier("Track")));
     tracks[0] = &trackFeature0->get();
 
-    const auto* trackFeature1 = channelGroup0.getFeature(2)->asA<const seqwires::TrackFeature>();
+    const auto* trackFeature1 = channelGroup0.getFeature(2)->as<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature1, nullptr);
     ASSERT_EQ(channelGroup0.getStepToChild(trackFeature1), babelwires::PathStep(babelwires::FieldIdentifier("ex1")));
     tracks[1] = &trackFeature1->get();
@@ -183,13 +183,13 @@ TEST(SmfTestSuiteTest, multichannelChords2) {
     const auto& channelGroup1 = dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(1));
     EXPECT_EQ(channelGroup1.getNumFeatures(), 2);
 
-    const auto* channelNumFeature2 = channelGroup1.getFeature(0)->asA<const babelwires::IntFeature>();
+    const auto* channelNumFeature2 = channelGroup1.getFeature(0)->as<const babelwires::IntFeature>();
     ASSERT_NE(channelNumFeature2, nullptr);
     ASSERT_EQ(channelGroup1.getStepToChild(channelNumFeature2),
               babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
     EXPECT_EQ(channelNumFeature2->get(), 2);
 
-    const auto* trackFeature2 = channelGroup1.getFeature(1)->asA<const seqwires::TrackFeature>();
+    const auto* trackFeature2 = channelGroup1.getFeature(1)->as<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature2, nullptr);
     ASSERT_EQ(channelGroup1.getStepToChild(trackFeature2), babelwires::PathStep(babelwires::FieldIdentifier("Track")));
     tracks[2] = &trackFeature2->get();
@@ -206,7 +206,7 @@ TEST(SmfTestSuiteTest, multichannelChords3) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();
@@ -224,13 +224,13 @@ TEST(SmfTestSuiteTest, multichannelChords3) {
             dynamic_cast<const smf::source::ExtensibleChannelGroup&>(smfFeature->getMidiTrack(i));
         EXPECT_EQ(channelGroup.getNumFeatures(), 2);
 
-        const auto* channelNumFeature = channelGroup.getFeature(0)->asA<const babelwires::IntFeature>();
+        const auto* channelNumFeature = channelGroup.getFeature(0)->as<const babelwires::IntFeature>();
         ASSERT_NE(channelNumFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(channelNumFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("ChanNo")));
         EXPECT_EQ(channelNumFeature->get(), expectedChannelMapping[i]);
 
-        const auto* trackFeature = channelGroup.getFeature(1)->asA<const seqwires::TrackFeature>();
+        const auto* trackFeature = channelGroup.getFeature(1)->as<const seqwires::TrackFeature>();
         ASSERT_NE(trackFeature, nullptr);
         ASSERT_EQ(channelGroup.getStepToChild(trackFeature),
                   babelwires::PathStep(babelwires::FieldIdentifier("Track")));
@@ -249,13 +249,13 @@ TEST(SmfTestSuiteTest, trackLength) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format0SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format0SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     EXPECT_EQ(smfFeature->getNumMidiTracks(), 1);
     const auto& channelGroup = dynamic_cast<const smf::source::RecordChannelGroup&>(smfFeature->getMidiTrack(0));
     EXPECT_EQ(channelGroup.getNumFeatures(), 1);
-    const auto* trackFeature = channelGroup.getFeature(0)->asA<const seqwires::TrackFeature>();
+    const auto* trackFeature = channelGroup.getFeature(0)->as<const seqwires::TrackFeature>();
     ASSERT_NE(trackFeature, nullptr);
 
     const seqwires::Track& track = trackFeature->get();
@@ -269,7 +269,7 @@ TEST(SmfTestSuiteTest, tempoTest) {
 
     const auto feature = smf::parseSmfSequence(midiFile, log);
     ASSERT_NE(feature, nullptr);
-    auto smfFeature = feature.get()->asA<const smf::source::Format1SmfFeature>();
+    auto smfFeature = feature.get()->as<const smf::source::Format1SmfFeature>();
     ASSERT_NE(smfFeature, nullptr);
 
     const auto& metadata = smfFeature->getMidiMetadata();

--- a/SeqWiresLib/Functions/splitAtPitchFunction.cpp
+++ b/SeqWiresLib/Functions/splitAtPitchFunction.cpp
@@ -8,7 +8,7 @@ namespace {
         NotesAbove(const seqwires::Track& track, seqwires::Pitch pitch) : seqwires::FilteredTrackIterator<>(track), m_pitch(pitch) {}
 
         virtual bool isEventOfInterest(const seqwires::TrackEvent& event) override {
-            if (const seqwires::NoteEvent* noteEvent = event.asA<seqwires::NoteEvent>()) {
+            if (const seqwires::NoteEvent* noteEvent = event.as<seqwires::NoteEvent>()) {
                 return noteEvent->m_pitch >= m_pitch;
             }
             return false;
@@ -21,7 +21,7 @@ namespace {
         NotesBelow(const seqwires::Track& track, seqwires::Pitch pitch) : seqwires::FilteredTrackIterator<>(track), m_pitch(pitch) {}
 
         virtual bool isEventOfInterest(const seqwires::TrackEvent& event) override {
-            if (const seqwires::NoteEvent* noteEvent = event.asA<seqwires::NoteEvent>()) {
+            if (const seqwires::NoteEvent* noteEvent = event.as<seqwires::NoteEvent>()) {
                 return noteEvent->m_pitch < m_pitch;
             }
             return false;
@@ -34,7 +34,7 @@ namespace {
         NotNotes(const seqwires::Track& track) : seqwires::FilteredTrackIterator<>(track) {}
 
         virtual bool isEventOfInterest(const seqwires::TrackEvent& event) override {
-            return event.asA<seqwires::NoteEvent>() == nullptr;
+            return event.as<seqwires::NoteEvent>() == nullptr;
         }
 
         seqwires::Pitch m_pitch;

--- a/SeqWiresLib/Utilities/filteredTrackIterator.hpp
+++ b/SeqWiresLib/Utilities/filteredTrackIterator.hpp
@@ -23,7 +23,7 @@ namespace seqwires {
         using value_type = EVENT;
 
         /// The default implementation just selects by type
-        virtual bool isEventOfInterest(const TrackEvent& event) { return event.asA<EVENT>(); }
+        virtual bool isEventOfInterest(const TrackEvent& event) { return event.as<EVENT>(); }
 
         /// The iterator must be initialized after construction by called initBegin or initEnd.
         FilteredTrackIterator(const Track& track);

--- a/SeqWiresLib/Utilities/filteredTrackIterator_inl.hpp
+++ b/SeqWiresLib/Utilities/filteredTrackIterator_inl.hpp
@@ -35,13 +35,13 @@ template <typename EVENT> seqwires::FilteredTrackIterator<EVENT>& seqwires::Filt
 
 template <typename EVENT> const EVENT& seqwires::FilteredTrackIterator<EVENT>::operator*() const {
     assert(m_isInitialized && "The iterator is not initialized. Call initBegin or initEnd.");
-    assert(m_iterator->asA<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
+    assert(m_iterator->as<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
     return m_event.hasEvent() ? *m_event : static_cast<const EVENT&>(*m_iterator);
 }
 
 template <typename EVENT> const EVENT* seqwires::FilteredTrackIterator<EVENT>::operator->() const {
     assert(m_isInitialized && "The iterator is not initialized. Call initBegin or initEnd.");
-    assert(m_iterator->asA<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
+    assert(m_iterator->as<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
     return m_event.hasEvent() ? &*m_event : static_cast<const EVENT*>(&*m_iterator);
 }
 
@@ -65,7 +65,7 @@ template <typename EVENT> void seqwires::FilteredTrackIterator<EVENT>::advance()
         if (isEventOfInterest(*m_iterator)) {
             // Only copy the event into the StreamEventHolder if necessary.
             if (timeSinceLastEvent != m_iterator->getTimeSinceLastEvent()) {
-                assert(m_iterator->asA<EVENT>() &&
+                assert(m_iterator->as<EVENT>() &&
                        "m_iterator should never stop on an event of the wrong type.");
                 m_event = static_cast<const EVENT&>(*m_iterator);
                 m_event->setTimeSinceLastEvent(timeSinceLastEvent);

--- a/SeqWiresLib/Utilities/filteredTrackIterator_inl.hpp
+++ b/SeqWiresLib/Utilities/filteredTrackIterator_inl.hpp
@@ -35,13 +35,13 @@ template <typename EVENT> seqwires::FilteredTrackIterator<EVENT>& seqwires::Filt
 
 template <typename EVENT> const EVENT& seqwires::FilteredTrackIterator<EVENT>::operator*() const {
     assert(m_isInitialized && "The iterator is not initialized. Call initBegin or initEnd.");
-    assert(dynamic_cast<const EVENT*>(&*m_iterator) && "m_iterator should never stop on an event of the wrong type.");
+    assert(m_iterator->asA<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
     return m_event.hasEvent() ? *m_event : static_cast<const EVENT&>(*m_iterator);
 }
 
 template <typename EVENT> const EVENT* seqwires::FilteredTrackIterator<EVENT>::operator->() const {
     assert(m_isInitialized && "The iterator is not initialized. Call initBegin or initEnd.");
-    assert(dynamic_cast<const EVENT*>(&*m_iterator) && "m_iterator should never stop on an event of the wrong type.");
+    assert(m_iterator->asA<EVENT>() && "m_iterator should never stop on an event of the wrong type.");
     return m_event.hasEvent() ? &*m_event : static_cast<const EVENT*>(&*m_iterator);
 }
 
@@ -65,7 +65,7 @@ template <typename EVENT> void seqwires::FilteredTrackIterator<EVENT>::advance()
         if (isEventOfInterest(*m_iterator)) {
             // Only copy the event into the StreamEventHolder if necessary.
             if (timeSinceLastEvent != m_iterator->getTimeSinceLastEvent()) {
-                assert(dynamic_cast<const EVENT*>(&*m_iterator) &&
+                assert(m_iterator->asA<EVENT>() &&
                        "m_iterator should never stop on an event of the wrong type.");
                 m_event = static_cast<const EVENT&>(*m_iterator);
                 m_event->setTimeSinceLastEvent(timeSinceLastEvent);

--- a/SeqWiresLib/Utilities/monophonicNoteIterator.cpp
+++ b/SeqWiresLib/Utilities/monophonicNoteIterator.cpp
@@ -8,18 +8,18 @@
 #include "SeqWiresLib/Utilities/monophonicNoteIterator.hpp"
 
 bool seqwires::MonophonicNoteIterator::isEventOfInterest(const TrackEvent& event) {
-    if (const NoteOnEvent* noteOn = event.asA<NoteOnEvent>()) {
+    if (const NoteOnEvent* noteOn = event.as<NoteOnEvent>()) {
         if (!m_noteIsActive) {
             m_activePitch = noteOn->m_pitch;
             m_noteIsActive = true;
             return true;
         }
-    } else if (const NoteOffEvent* noteOff = event.asA<NoteOffEvent>()) {
+    } else if (const NoteOffEvent* noteOff = event.as<NoteOffEvent>()) {
         if (m_noteIsActive && (noteOff->m_pitch == m_activePitch)) {
             m_noteIsActive = false;
             return true;
         }
-    } else if (const NoteEvent* note = event.asA<NoteEvent>()) {
+    } else if (const NoteEvent* note = event.as<NoteEvent>()) {
         if ((m_interiorEventFilter == AllEvents) && m_noteIsActive && (note->m_pitch == m_activePitch)) {
             return true;
         }

--- a/SeqWiresLibUi/RowModels/trackRowModel.cpp
+++ b/SeqWiresLibUi/RowModels/trackRowModel.cpp
@@ -15,7 +15,7 @@
 
 const seqwires::TrackFeature& seqwiresUi::TrackRowModel::getTrackFeature() const {
     // Favour output here, since tracks cannot be directly edited.
-    assert(getOutputThenInputFeature()->asA<const seqwires::TrackFeature>() && "Wrong type of feature stored");
+    assert(getOutputThenInputFeature()->as<const seqwires::TrackFeature>() && "Wrong type of feature stored");
     return *static_cast<const seqwires::TrackFeature*>(getOutputThenInputFeature());
 }
 

--- a/SeqWiresLibUi/RowModels/trackRowModel.cpp
+++ b/SeqWiresLibUi/RowModels/trackRowModel.cpp
@@ -15,7 +15,7 @@
 
 const seqwires::TrackFeature& seqwiresUi::TrackRowModel::getTrackFeature() const {
     // Favour output here, since tracks cannot be directly edited.
-    assert(dynamic_cast<const seqwires::TrackFeature*>(getOutputThenInputFeature()) && "Wrong type of feature stored");
+    assert(getOutputThenInputFeature()->asA<const seqwires::TrackFeature>() && "Wrong type of feature stored");
     return *static_cast<const seqwires::TrackFeature*>(getOutputThenInputFeature());
 }
 

--- a/Tests/SeqWiresLib/concatenateProcessorTest.cpp
+++ b/Tests/SeqWiresLib/concatenateProcessorTest.cpp
@@ -69,15 +69,15 @@ TEST(ConcatenateProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* inputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Input")));
-    auto* outputTrack = dynamic_cast<seqwires::TrackFeature*>(&processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Output")));
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Input")).asA<babelwires::ArrayFeature>();
+    auto* outputTrack = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Output")).asA<seqwires::TrackFeature>();
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputTrack, nullptr);
 
     EXPECT_EQ(inputArray->getNumFeatures(), 2);
     EXPECT_EQ(outputTrack->get().getDuration(), 0);
 
-    auto getInputTrack = [&inputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&inputArray->getChildFromStep(i)); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getInputTrack(1), nullptr);

--- a/Tests/SeqWiresLib/concatenateProcessorTest.cpp
+++ b/Tests/SeqWiresLib/concatenateProcessorTest.cpp
@@ -69,15 +69,15 @@ TEST(ConcatenateProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Input")).asA<babelwires::ArrayFeature>();
-    auto* outputTrack = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Output")).asA<seqwires::TrackFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Input")).as<babelwires::ArrayFeature>();
+    auto* outputTrack = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Output")).as<seqwires::TrackFeature>();
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputTrack, nullptr);
 
     EXPECT_EQ(inputArray->getNumFeatures(), 2);
     EXPECT_EQ(outputTrack->get().getDuration(), 0);
 
-    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getInputTrack(1), nullptr);

--- a/Tests/SeqWiresLib/excerptProcessorTest.cpp
+++ b/Tests/SeqWiresLib/excerptProcessorTest.cpp
@@ -130,10 +130,10 @@ TEST(ExcerptProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* startFeature = dynamic_cast<babelwires::RationalFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Start")));
-    auto* durationFeature = dynamic_cast<babelwires::RationalFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Duratn")));
-    auto* inputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
-    auto* outputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
+    auto* startFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Start")).asA<babelwires::RationalFeature>();
+    auto* durationFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Duratn")).asA<babelwires::RationalFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
     ASSERT_NE(startFeature, nullptr);
     ASSERT_NE(durationFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
@@ -142,8 +142,8 @@ TEST(ExcerptProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&inputArray->getChildFromStep(i)); };
-    auto getOutputTrack = [&outputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&outputArray->getChildFromStep(i)); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/SeqWiresLib/excerptProcessorTest.cpp
+++ b/Tests/SeqWiresLib/excerptProcessorTest.cpp
@@ -130,10 +130,10 @@ TEST(ExcerptProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* startFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Start")).asA<babelwires::RationalFeature>();
-    auto* durationFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Duratn")).asA<babelwires::RationalFeature>();
-    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
-    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* startFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Start")).as<babelwires::RationalFeature>();
+    auto* durationFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Duratn")).as<babelwires::RationalFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
     ASSERT_NE(startFeature, nullptr);
     ASSERT_NE(durationFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
@@ -142,8 +142,8 @@ TEST(ExcerptProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
-    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/SeqWiresLib/monophonicNoteIteratorTest.cpp
+++ b/Tests/SeqWiresLib/monophonicNoteIteratorTest.cpp
@@ -86,39 +86,39 @@ TEST(MonophonicNoteIterator, OnOffOnly) {
     auto [it, end] = seqwires::iterateOverMonotonicNotes(track, seqwires::MonophonicNoteIterator::OnOffOnly);
 
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOnEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->m_pitch, 40);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 0);
+    ASSERT_NE(it->as<seqwires::NoteOnEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->m_pitch, 40);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 0);
 
     ++it;
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOffEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->m_pitch, 40);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 1);
+    ASSERT_NE(it->as<seqwires::NoteOffEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->m_pitch, 40);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 1);
 
     ++it;
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOnEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->m_pitch, 40);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 0);
+    ASSERT_NE(it->as<seqwires::NoteOnEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->m_pitch, 40);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 0);
 
     ++it;
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOffEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->m_pitch, 40);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 2);
+    ASSERT_NE(it->as<seqwires::NoteOffEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->m_pitch, 40);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 2);
 
     ++it;
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOnEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->m_pitch, 50);
-    EXPECT_EQ(it->asA<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 5);
+    ASSERT_NE(it->as<seqwires::NoteOnEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->m_pitch, 50);
+    EXPECT_EQ(it->as<seqwires::NoteOnEvent>()->getTimeSinceLastEvent(), 5);
 
     ++it;
     ASSERT_NE(it, end);
-    ASSERT_NE(it->asA<seqwires::NoteOffEvent>(), nullptr);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->m_pitch, 50);
-    EXPECT_EQ(it->asA<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 7);
+    ASSERT_NE(it->as<seqwires::NoteOffEvent>(), nullptr);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->m_pitch, 50);
+    EXPECT_EQ(it->as<seqwires::NoteOffEvent>()->getTimeSinceLastEvent(), 7);
 
     ++it;
     ASSERT_EQ(it, end);

--- a/Tests/SeqWiresLib/repeatProcessorTest.cpp
+++ b/Tests/SeqWiresLib/repeatProcessorTest.cpp
@@ -50,9 +50,9 @@ TEST(RepeatProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* countFeature = dynamic_cast<babelwires::IntFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Count")));
-    auto* inputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
-    auto* outputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
+    auto* countFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Count")).asA<babelwires::IntFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
     ASSERT_NE(countFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputArray, nullptr);
@@ -61,8 +61,8 @@ TEST(RepeatProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&inputArray->getChildFromStep(i)); };
-    auto getOutputTrack = [&outputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&outputArray->getChildFromStep(i)); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/SeqWiresLib/repeatProcessorTest.cpp
+++ b/Tests/SeqWiresLib/repeatProcessorTest.cpp
@@ -50,9 +50,9 @@ TEST(RepeatProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* countFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Count")).asA<babelwires::IntFeature>();
-    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
-    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* countFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Count")).as<babelwires::IntFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
     ASSERT_NE(countFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputArray, nullptr);
@@ -61,8 +61,8 @@ TEST(RepeatProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
-    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/SeqWiresLib/trackTest.cpp
+++ b/Tests/SeqWiresLib/trackTest.cpp
@@ -64,7 +64,7 @@ TEST(Track, BlocksAndAlignment) {
     for (const auto& event : track) {
         EXPECT_EQ(event.getTimeSinceLastEvent(), 1);
         if (count % 2) {
-            EXPECT_NE(event.asA<TestEvent>(), nullptr);
+            EXPECT_NE(event.as<TestEvent>(), nullptr);
             const TestEvent& e = static_cast<const TestEvent&>(event);
             EXPECT_EQ(e.m_big[2], (count / 2));
         }

--- a/Tests/SeqWiresLib/trackTest.cpp
+++ b/Tests/SeqWiresLib/trackTest.cpp
@@ -64,7 +64,7 @@ TEST(Track, BlocksAndAlignment) {
     for (const auto& event : track) {
         EXPECT_EQ(event.getTimeSinceLastEvent(), 1);
         if (count % 2) {
-            EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+            EXPECT_NE(event.asA<TestEvent>(), nullptr);
             const TestEvent& e = static_cast<const TestEvent&>(event);
             EXPECT_EQ(e.m_big[2], (count / 2));
         }

--- a/Tests/SeqWiresLib/transposeProcessorTest.cpp
+++ b/Tests/SeqWiresLib/transposeProcessorTest.cpp
@@ -133,9 +133,9 @@ TEST(TransposeProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* pitchOffsetFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Offset")).asA<babelwires::IntFeature>();
-    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
-    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* pitchOffsetFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Offset")).as<babelwires::IntFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
     ASSERT_NE(pitchOffsetFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputArray, nullptr);
@@ -144,8 +144,8 @@ TEST(TransposeProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
-    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/SeqWiresLib/transposeProcessorTest.cpp
+++ b/Tests/SeqWiresLib/transposeProcessorTest.cpp
@@ -133,9 +133,9 @@ TEST(TransposeProcessorTest, processor) {
     processor.getInputFeature()->setToDefault();
     processor.getOutputFeature()->setToDefault();
 
-    auto* pitchOffsetFeature = dynamic_cast<babelwires::IntFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Offset")));
-    auto* inputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
-    auto* outputArray = dynamic_cast<babelwires::ArrayFeature*>(&processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")));
+    auto* pitchOffsetFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Offset")).asA<babelwires::IntFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).asA<babelwires::ArrayFeature>();
     ASSERT_NE(pitchOffsetFeature, nullptr);
     ASSERT_NE(inputArray, nullptr);
     ASSERT_NE(outputArray, nullptr);
@@ -144,8 +144,8 @@ TEST(TransposeProcessorTest, processor) {
     EXPECT_EQ(inputArray->getNumFeatures(), 1);
     EXPECT_EQ(outputArray->getNumFeatures(), 1);
 
-    auto getInputTrack = [&inputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&inputArray->getChildFromStep(i)); };
-    auto getOutputTrack = [&outputArray](int i) { return dynamic_cast<seqwires::TrackFeature*>(&outputArray->getChildFromStep(i)); };
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).asA<seqwires::TrackFeature>(); };
 
     ASSERT_NE(getInputTrack(0), nullptr);
     ASSERT_NE(getOutputTrack(0), nullptr);

--- a/Tests/TestUtils/seqTestUtils.cpp
+++ b/Tests/TestUtils/seqTestUtils.cpp
@@ -32,7 +32,7 @@ void testUtils::testSimpleNotes(const std::vector<seqwires::Pitch>& expectedPitc
 
     for (auto pitch : expectedPitches) {
         EXPECT_NE(noteIterator, endIterator);
-        auto noteOn = noteIterator->asA<const seqwires::NoteOnEvent>();
+        auto noteOn = noteIterator->as<const seqwires::NoteOnEvent>();
         ASSERT_NE(noteOn, nullptr);
         EXPECT_EQ(noteOn->getTimeSinceLastEvent(), 0);
         EXPECT_EQ(noteOn->m_pitch, pitch);
@@ -40,7 +40,7 @@ void testUtils::testSimpleNotes(const std::vector<seqwires::Pitch>& expectedPitc
         ++noteIterator;
 
         EXPECT_NE(noteIterator, endIterator);
-        auto noteOff = noteIterator->asA<seqwires::NoteOffEvent>();
+        auto noteOff = noteIterator->as<seqwires::NoteOffEvent>();
         ASSERT_NE(noteOff, nullptr);
         EXPECT_EQ(noteOff->getTimeSinceLastEvent(), expectedNoteDuration);
         EXPECT_EQ(noteOff->m_pitch, pitch);
@@ -74,7 +74,7 @@ void testUtils::testNotes(const std::vector<NoteInfo>& expectedNotes, const seqw
     for (auto note : expectedNotes)
     {
         EXPECT_NE(noteIterator, endIterator);
-        auto noteOn = noteIterator->asA<const seqwires::NoteOnEvent>();
+        auto noteOn = noteIterator->as<const seqwires::NoteOnEvent>();
         ASSERT_NE(noteOn, nullptr);
         EXPECT_EQ(noteOn->getTimeSinceLastEvent(), note.m_noteOnTime);
         EXPECT_EQ(noteOn->m_pitch, note.m_pitch);
@@ -82,7 +82,7 @@ void testUtils::testNotes(const std::vector<NoteInfo>& expectedNotes, const seqw
         ++noteIterator;
 
         EXPECT_NE(noteIterator, endIterator);
-        auto noteOff = noteIterator->asA<seqwires::NoteOffEvent>();
+        auto noteOff = noteIterator->as<seqwires::NoteOffEvent>();
         ASSERT_NE(noteOff, nullptr);
         EXPECT_EQ(noteOff->getTimeSinceLastEvent(), note.m_noteOffTime);
         EXPECT_EQ(noteOff->m_pitch, note.m_pitch);
@@ -114,7 +114,7 @@ void testUtils::testChords(const std::vector<ChordInfo>& expectedChords, const s
 
     for (auto chord : expectedChords) {
         EXPECT_NE(chordIterator, endIterator);
-        auto chordOn = chordIterator->asA<const seqwires::ChordOnEvent>();
+        auto chordOn = chordIterator->as<const seqwires::ChordOnEvent>();
         ASSERT_NE(chordOn, nullptr);
         EXPECT_EQ(chordOn->getTimeSinceLastEvent(), chord.m_chordOnTime);
         EXPECT_EQ(chordOn->m_chordType, chord.m_chordType);
@@ -122,7 +122,7 @@ void testUtils::testChords(const std::vector<ChordInfo>& expectedChords, const s
         ++chordIterator;
 
         EXPECT_NE(chordIterator, endIterator);
-        auto chordOff = chordIterator->asA<seqwires::ChordOffEvent>();
+        auto chordOff = chordIterator->as<seqwires::ChordOffEvent>();
         ASSERT_NE(chordOff, nullptr);
         EXPECT_EQ(chordOff->getTimeSinceLastEvent(), chord.m_chordOffTime);
         ++chordIterator;


### PR DESCRIPTION
Use as methods instead of dynamic_cast. See corresponding change to BabelWires repo.