### PR TITLE
Editable Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The result is like a simple [musical round](https://en.wikipedia.org/wiki/Round_
 
 ![Screenshot showing several nodes wired together](https://raw.githubusercontent.com/Malcohol/BabelWires/main/Docs/screenshot.png "An example SeqWires project")
 
+Here's a screenshot of the MapEditor defining a map between chord types:
+
+![Screenshot showing the MapEditor](https://raw.githubusercontent.com/Malcohol/BabelWires/main/Docs/mapEditor.png "Screenshot of the MapEditor defining a map between chordTypes")
+
 Right now, the supported formats are:
 * SMF (standard MIDI file)
 * Many more formats to come :D 

--- a/SeqWiresExe/main.cpp
+++ b/SeqWiresExe/main.cpp
@@ -13,7 +13,7 @@
 #include "BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp"
 #include "BabelWiresQtUi/uiProjectContext.hpp"
 
-#include "BabelWiresLib/Enums/enum.hpp"
+#include "BabelWiresLib/TypeSystem/typeSystem.hpp"
 #include "Common/Identifiers/identifierRegistry.hpp"
 #include "BabelWiresLib/FileFormat/fileFeature.hpp"
 #include "BabelWiresLib/FileFormat/sourceFileFormat.hpp"
@@ -73,14 +73,14 @@ int main(int argc, char* argv[]) {
         ProcessorFactoryRegistry processorReg;
         babelwires::AutomaticDeserializationRegistry deserializationRegistry;
         babelwires::RowModelRegistry rowModelRegistry;
-        babelwires::EnumRegistry enumRegistry;
+        babelwires::TypeSystem typeSystem;
 
         const unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
         babelwires::logDebug() << "The random seed was " << seed;
         std::default_random_engine randomEngine(seed);
 
         babelwires::UiProjectContext context{sourceFileFormatReg,     targetFileFormatReg, processorReg,
-                                             deserializationRegistry, enumRegistry,        randomEngine,
+                                             deserializationRegistry, typeSystem,        randomEngine,
                                              rowModelRegistry};
 
         context.m_applicationIdentity.m_applicationTitle = "Seqwires";

--- a/SeqWiresExe/main.cpp
+++ b/SeqWiresExe/main.cpp
@@ -8,13 +8,15 @@
 #include "Common/Audio/fileAudioDest.hpp"
 #include "Common/Audio/fileAudioSource.hpp"
 
-#include "BabelWiresLib/Features/Utilities/featureXml.hpp"
+#include "SeqWiresExe/seqWiresOptions.hpp"
 
 #include "BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp"
 #include "BabelWiresQtUi/uiProjectContext.hpp"
+#include "BabelWiresQtUi/uiMain.hpp"
+
+#include "BabelWiresLib/Features/Utilities/featureXml.hpp"
 
 #include "BabelWiresLib/TypeSystem/typeSystem.hpp"
-#include "Common/Identifiers/identifierRegistry.hpp"
 #include "BabelWiresLib/FileFormat/fileFeature.hpp"
 #include "BabelWiresLib/FileFormat/sourceFileFormat.hpp"
 #include "BabelWiresLib/FileFormat/targetFileFormat.hpp"
@@ -24,10 +26,10 @@
 #include "BabelWiresLib/Project/project.hpp"
 #include "BabelWiresLib/Project/projectData.hpp"
 #include "BabelWiresLib/Serialization/projectSerialization.hpp"
-#include "Common/IO/fileDataSource.hpp"
-#include "SeqWiresExe/seqWiresOptions.hpp"
+#include "BabelWiresLib/libRegistration.hpp"
 
-#include "BabelWiresQtUi/uiMain.hpp"
+#include "Common/Identifiers/identifierRegistry.hpp"
+#include "Common/IO/fileDataSource.hpp"
 #include "Common/Log/ostreamLogListener.hpp"
 #include "Common/Log/unifiedLog.hpp"
 #include "Common/Serialization/deserializationRegistry.hpp"
@@ -87,6 +89,7 @@ int main(int argc, char* argv[]) {
         context.m_applicationIdentity.m_projectExtension = ".seqwires";
 
         // register factories, etc.
+        babelwires::registerLib(context);
         seqwires::registerLib(context);
         seqwiresUi::registerLib(context);
         smf::registerLib(context);

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -3,6 +3,7 @@ SET( SEQWIRESLIB_SRCS
 	Features/trackFeature.cpp
 	Features/pitchFeature.cpp
 	Processors/chordsFromNotesProcessor.cpp
+	Processors/chordMapProcessor.cpp
 	Processors/concatenateProcessor.cpp
 	Processors/excerptProcessor.cpp
 	Processors/mergeProcessor.cpp

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -14,6 +14,7 @@ SET( SEQWIRESLIB_SRCS
 	Processors/transposeProcessor.cpp
 	Functions/appendTrackFunction.cpp
 	Functions/chordsFromNotesFunction.cpp
+	Functions/mapChordsFunction.cpp
 	Functions/excerptFunction.cpp
 	Functions/repeatFunction.cpp
 	Functions/mergeFunction.cpp

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -26,6 +26,7 @@ SET( SEQWIRESLIB_SRCS
 	Tracks/track.cpp
 	chord.cpp
 	musicTypes.cpp
+	pitchClass.cpp
 	Utilities/monophonicNoteIterator.cpp
 	libRegistration.cpp
    )

--- a/SeqWiresLib/Functions/chordsFromNotesFunction.cpp
+++ b/SeqWiresLib/Functions/chordsFromNotesFunction.cpp
@@ -105,7 +105,7 @@ namespace {
         if ((it != recognizedIntervals.end()) && (it->m_intervals == intervals)) {
             return it->m_chordType;
         }
-        return seqwires::ChordType::Value::NotAChord;
+        return seqwires::ChordType::Value::NotAValue;
     }
 
     /// The pitches of the set of currently playing notes.
@@ -148,7 +148,7 @@ namespace {
             // Try each inversion.
             for (unsigned int i = 0; i < numPitches; ++i) {
                 const seqwires::ChordType::Value chordType = getMatchingChordTypeFromIntervals(interval);
-                if (chordType != seqwires::ChordType::Value::NotAChord) {
+                if (chordType != seqwires::ChordType::Value::NotAValue) {
                     return seqwires::Chord{seqwires::pitchToPitchClass(m_pitches[i]), chordType};
                 }
                 if (i < numPitches - 1) {
@@ -178,12 +178,12 @@ seqwires::Track seqwires::chordsFromNotesFunction(const Track& sourceTrack) {
         if (event.getTimeSinceLastEvent() > 0) {
             const Chord bestChord = activePitches.getBestMatchChord();
             if (currentChord != bestChord) {
-                if (currentChord.m_chordType != ChordType::Value::NotAChord) {
+                if (currentChord.m_chordType != ChordType::Value::NotAValue) {
                     trackOut.addEvent(ChordOffEvent(timeSinceLastChordEvent));
-                    currentChord.m_chordType = ChordType::Value::NotAChord;
+                    currentChord.m_chordType = ChordType::Value::NotAValue;
                     timeSinceLastChordEvent = 0;
                 }
-                if (bestChord.m_chordType != ChordType::Value::NotAChord) {
+                if (bestChord.m_chordType != ChordType::Value::NotAValue) {
                     trackOut.addEvent(
                         ChordOnEvent(timeSinceLastChordEvent, bestChord));
                     currentChord = bestChord;
@@ -200,7 +200,7 @@ seqwires::Track seqwires::chordsFromNotesFunction(const Track& sourceTrack) {
             activePitches.removePitch(noteOffEvent->m_pitch);
         }
     }
-    if (currentChord.m_chordType != ChordType::Value::NotAChord) {
+    if (currentChord.m_chordType != ChordType::Value::NotAValue) {
         trackOut.addEvent(ChordOffEvent(timeSinceLastChordEvent));
     }
     trackOut.setDuration(sourceTrack.getDuration());

--- a/SeqWiresLib/Functions/mapChordsFunction.cpp
+++ b/SeqWiresLib/Functions/mapChordsFunction.cpp
@@ -1,0 +1,56 @@
+/**
+ * Function which applies maps to chord events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include "SeqWiresLib/Functions/mapChordsFunction.hpp"
+
+#include <SeqWiresLib/Tracks/chordEvents.hpp>
+#include <SeqWiresLib/Tracks/trackEventHolder.hpp>
+#include <SeqWiresLib/chord.hpp>
+#include <SeqWiresLib/pitchClass.hpp>
+
+#include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumSourceMapApplicator.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+#include <BabelWiresLib/Features/modelExceptions.hpp>
+
+seqwires::Track seqwires::mapChordsFunction(const babelwires::TypeSystem& typeSystem, const Track& sourceTrack, const babelwires::MapData& chordTypeMapData, const babelwires::MapData& pitchClassMapData) {
+
+    if (!chordTypeMapData.isValid(typeSystem)) {
+        throw babelwires::ModelException() << "The Chord Type Map is not valid.";
+    }
+
+    const ChordType& chordType =
+        typeSystem.getEntryByIdentifier(seqwires::ChordType::getThisIdentifier())->is<ChordType>();
+    const babelwires::EnumToValueValueAdapter<ChordType> chordTypeTargetAdapter{chordType};
+    babelwires::EnumSourceMapApplicator<ChordType, ChordType::Value> chordTypeApplicator(chordTypeMapData, chordType, chordTypeTargetAdapter);
+
+    if (!pitchClassMapData.isValid(typeSystem)) {
+        throw babelwires::ModelException() << "The Pitch Class Map is not valid.";
+    }
+
+    const PitchClass& pitchClass =
+        typeSystem.getEntryByIdentifier(seqwires::PitchClass::getThisIdentifier())->is<PitchClass>();
+    const babelwires::EnumToValueValueAdapter<PitchClass> pitchClassTargetAdapter{pitchClass};
+    babelwires::EnumSourceMapApplicator<PitchClass, PitchClass::Value> pitchClassApplicator(pitchClassMapData, pitchClass, pitchClassTargetAdapter);
+
+    Track trackOut;
+
+    for (auto it = sourceTrack.begin(); it != sourceTrack.end(); ++it) {
+        if (it->as<ChordOnEvent>()) {
+            TrackEventHolder holder(*it);
+            Chord& chord = holder->is<ChordOnEvent>().m_chord;
+            chord.m_chordType = chordTypeApplicator[chord.m_chordType];
+            chord.m_root = pitchClassApplicator[chord.m_root];
+            trackOut.addEvent(holder.release());
+        } else {
+            trackOut.addEvent(*it);
+        }
+    }
+    trackOut.setDuration(sourceTrack.getDuration());
+    return trackOut;
+}

--- a/SeqWiresLib/Functions/mapChordsFunction.hpp
+++ b/SeqWiresLib/Functions/mapChordsFunction.hpp
@@ -1,0 +1,18 @@
+/**
+ * Function which applies maps to chord events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include "SeqWiresLib/Tracks/track.hpp"
+
+namespace babelwires {
+    class MapData;
+    class TypeSystem;
+}
+
+namespace seqwires {
+    /// Create tracks of chord events from tracks of note events.
+    Track mapChordsFunction(const babelwires::TypeSystem& typeSystem, const Track& sourceTrack, const babelwires::MapData& chordTypeMapData, const babelwires::MapData& pitchClassMapData);
+}

--- a/SeqWiresLib/Functions/monophonicSubtracksFunction.cpp
+++ b/SeqWiresLib/Functions/monophonicSubtracksFunction.cpp
@@ -16,9 +16,12 @@
 
 ENUM_DEFINE_ENUM_VALUE_SOURCE(MONOPHONIC_SUBTRACK_POLICY);
 
-seqwires::MonophonicSubtracksPolicyEnum::MonophonicSubtracksPolicyEnum()
-    : babelwires::RegisteredEnum<MonophonicSubtracksPolicyEnum>(REGISTERED_LONGID("MonoSubtracksPolicy", "Monophonic Subtracks Policy", "d9ae8da5-3001-45ff-b2ce-4375f7d18afd"), 1, ENUM_IDENTIFIER_VECTOR(MONOPHONIC_SUBTRACK_POLICY), 0) {}
+babelwires::LongIdentifier seqwires::MonophonicSubtracksPolicyEnum::getThisIdentifier() {
+    return REGISTERED_LONGID("MonoSubtracksPolicy", "Monophonic Subtracks Policy", "d9ae8da5-3001-45ff-b2ce-4375f7d18afd");
+}
 
+seqwires::MonophonicSubtracksPolicyEnum::MonophonicSubtracksPolicyEnum()
+    : babelwires::Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(MONOPHONIC_SUBTRACK_POLICY), 0) {}
 
 namespace {
     struct TrackInfo {

--- a/SeqWiresLib/Functions/monophonicSubtracksFunction.hpp
+++ b/SeqWiresLib/Functions/monophonicSubtracksFunction.hpp
@@ -18,9 +18,11 @@ namespace seqwires {
     X(LowEv, "Lower pitches evict", "7068c9fd-d80a-47fa-8f82-6b000cd1e0be")
 
     /// The enum that determines the algorithm used.
-    class MonophonicSubtracksPolicyEnum : public babelwires::RegisteredEnum<MonophonicSubtracksPolicyEnum> {
+    class MonophonicSubtracksPolicyEnum : public babelwires::Enum {
       public:
         MonophonicSubtracksPolicyEnum();
+
+        static babelwires::LongIdentifier getThisIdentifier();
 
         ENUM_DEFINE_CPP_ENUM(MONOPHONIC_SUBTRACK_POLICY);
     };

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -5,20 +5,26 @@
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
-#include "SeqWiresLib/Processors/chordMapProcessor.hpp"
+#include <SeqWiresLib/Processors/chordMapProcessor.hpp>
 
+#include <SeqWiresLib/Tracks/chordEvents.hpp>
+#include <SeqWiresLib/Tracks/trackEventHolder.hpp>
 #include <SeqWiresLib/chord.hpp>
 
-#include "BabelWiresLib/Features/mapFeature.hpp"
+#include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Features/rootFeature.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp>
+#include <BabelWiresLib/Maps/Helpers/unorderedMapApplicator.hpp>
+#include <BabelWiresLib/Project/projectContext.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 
-#include "Common/Identifiers/registeredIdentifier.hpp"
+#include <Common/Identifiers/registeredIdentifier.hpp>
 
 namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
-            : babelwires::MapFeature(
-                  babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()},
-                  babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()}) {}
+            : babelwires::MapFeature(babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()},
+                                     babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()}) {}
     };
 } // namespace
 
@@ -34,4 +40,32 @@ seqwires::ChordMapProcessor::Factory::Factory()
           REGISTERED_LONGID("ChordMapProcessor", "Chord Map", "b7227130-8274-4451-bd60-8fe34a74c4b6"), 1) {}
 
 void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input,
-                                               seqwires::TrackFeature& output) const {}
+                                               seqwires::TrackFeature& output) const {
+    const babelwires::MapData& mapData = m_chordTypeMapFeature->get();
+    const babelwires::ProjectContext& context = babelwires::RootFeature::getProjectContextAt(*m_chordTypeMapFeature);
+    if (!mapData.isValid(context)) {
+        throw babelwires::ModelException() << "The Map is not valid.";
+    }
+
+    const ChordType& chordType =
+        context.m_typeSystem.getEntryByIdentifier(seqwires::ChordType::getThisIdentifier())->is<ChordType>();
+
+    const babelwires::EnumToIndexValueAdapter adapter{chordType};
+
+    babelwires::UnorderedMapApplicator<unsigned int, unsigned int> applicator(mapData, adapter, adapter);
+
+    const Track& trackIn = input.get();
+    Track trackOut;
+
+    for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
+        if (it->as<ChordOnEvent>()) {
+            TrackEventHolder holder(*it);
+            ChordType::Value& type = holder->is<ChordOnEvent>().m_chord.m_chordType;
+            type = static_cast<ChordType::Value>(applicator[static_cast<unsigned int>(type)]);
+            trackOut.addEvent(holder.release());
+        } else {
+            trackOut.addEvent(*it);
+        }
+    }
+    trackOut.setDuration(trackIn.getDuration());
+}

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -16,7 +16,10 @@ namespace {
 }
 
 seqwires::ChordMapProcessor::ChordMapProcessor() {
-    m_chordTypeMapFeature = m_inputFeature->addField(std::make_unique<ChordTypeMap>(),
+    babelwires::MapFeature::TypeSet sourceIds = { "ChordType" };
+    babelwires::MapFeature::TypeSet targetIds = { "ChordType" };
+        
+    m_chordTypeMapFeature = m_inputFeature->addField(std::make_unique<ChordTypeMap>(sourceIds, targetIds),
                                           REGISTERED_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"));
     addArrayFeature(REGISTERED_ID("Tracks", "Tracks", "24e56b0d-eb1e-4c93-97fd-ba4d639e112a"));
 }

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -1,33 +1,36 @@
 /**
  * Processor which applies a map to chord events.
- * 
+ *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "SeqWiresLib/Processors/chordMapProcessor.hpp"
+
+#include <SeqWiresLib/chord.hpp>
 
 #include "BabelWiresLib/Features/mapFeature.hpp"
 
 #include "Common/Identifiers/registeredIdentifier.hpp"
 
 namespace {
-    using ChordTypeMap = babelwires::MapFeature;
-}
+    struct ChordTypeMap : babelwires::MapFeature {
+        ChordTypeMap()
+            : babelwires::MapFeature(
+                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getRegisteredInstance()->getIdentifier()},
+                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getRegisteredInstance()->getIdentifier()}) {}
+    };
+} // namespace
 
 seqwires::ChordMapProcessor::ChordMapProcessor() {
-    babelwires::MapFeature::TypeSet sourceIds = { "ChordType" };
-    babelwires::MapFeature::TypeSet targetIds = { "ChordType" };
-        
-    m_chordTypeMapFeature = m_inputFeature->addField(std::make_unique<ChordTypeMap>(sourceIds, targetIds),
-                                          REGISTERED_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"));
+    m_chordTypeMapFeature = m_inputFeature->addField(
+        std::make_unique<ChordTypeMap>(), REGISTERED_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"));
     addArrayFeature(REGISTERED_ID("Tracks", "Tracks", "24e56b0d-eb1e-4c93-97fd-ba4d639e112a"));
 }
 
 seqwires::ChordMapProcessor::Factory::Factory()
-    : CommonProcessorFactory(REGISTERED_LONGID("ChordMapProcessor", "Chord Map", "b7227130-8274-4451-bd60-8fe34a74c4b6"), 1) {}
+    : CommonProcessorFactory(
+          REGISTERED_LONGID("ChordMapProcessor", "Chord Map", "b7227130-8274-4451-bd60-8fe34a74c4b6"), 1) {}
 
-void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const {
-    
-}
-
+void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input,
+                                               seqwires::TrackFeature& output) const {}

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -25,11 +25,19 @@ namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
             : babelwires::MapFeature(seqwires::ChordType::getThisIdentifier(), seqwires::ChordType::getThisIdentifier()) {}
+
+        babelwires::MapData getDefaultMapData() const override {
+            return getStandardDefaultMapData(babelwires::MapEntryData::Kind::AllToSame);
+        }
     };
 
     struct PitchClassMap : babelwires::MapFeature {
         PitchClassMap()
             : babelwires::MapFeature(seqwires::PitchClass::getThisIdentifier(), seqwires::PitchClass::getThisIdentifier()) {}
+
+        babelwires::MapData getDefaultMapData() const override {
+            return getStandardDefaultMapData(babelwires::MapEntryData::Kind::AllToSame);
+        }
     };
 } // namespace
 

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -1,0 +1,30 @@
+/**
+ * Processor which applies a map to chord events.
+ * 
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include "SeqWiresLib/Processors/chordMapProcessor.hpp"
+
+#include "BabelWiresLib/Features/mapFeature.hpp"
+
+#include "Common/Identifiers/registeredIdentifier.hpp"
+
+namespace {
+    using ChordTypeMap = babelwires::MapFeature;
+}
+
+seqwires::ChordMapProcessor::ChordMapProcessor() {
+    m_chordTypeMapFeature = m_inputFeature->addField(std::make_unique<ChordTypeMap>(),
+                                          REGISTERED_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"));
+    addArrayFeature(REGISTERED_ID("Tracks", "Tracks", "24e56b0d-eb1e-4c93-97fd-ba4d639e112a"));
+}
+
+seqwires::ChordMapProcessor::Factory::Factory()
+    : CommonProcessorFactory(REGISTERED_LONGID("ChordMapProcessor", "Chord Map", "b7227130-8274-4451-bd60-8fe34a74c4b6"), 1) {}
+
+void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const {
+    
+}
+

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -7,15 +7,12 @@
  **/
 #include <SeqWiresLib/Processors/chordMapProcessor.hpp>
 
-#include <SeqWiresLib/Tracks/chordEvents.hpp>
-#include <SeqWiresLib/Tracks/trackEventHolder.hpp>
+#include <SeqWiresLib/Functions/mapChordsFunction.hpp>
 #include <SeqWiresLib/chord.hpp>
 #include <SeqWiresLib/pitchClass.hpp>
 
 #include <BabelWiresLib/Features/mapFeature.hpp>
 #include <BabelWiresLib/Features/rootFeature.hpp>
-#include <BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp>
-#include <BabelWiresLib/Maps/Helpers/enumSourceMapApplicator.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 
@@ -24,7 +21,8 @@
 namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
-            : babelwires::MapFeature(seqwires::ChordType::getThisIdentifier(), seqwires::ChordType::getThisIdentifier()) {}
+            : babelwires::MapFeature(seqwires::ChordType::getThisIdentifier(),
+                                     seqwires::ChordType::getThisIdentifier()) {}
 
         babelwires::MapData getDefaultMapData() const override {
             return getStandardDefaultMapData(babelwires::MapEntryData::Kind::AllToSame);
@@ -33,7 +31,8 @@ namespace {
 
     struct PitchClassMap : babelwires::MapFeature {
         PitchClassMap()
-            : babelwires::MapFeature(seqwires::PitchClass::getThisIdentifier(), seqwires::PitchClass::getThisIdentifier()) {}
+            : babelwires::MapFeature(seqwires::PitchClass::getThisIdentifier(),
+                                     seqwires::PitchClass::getThisIdentifier()) {}
 
         babelwires::MapData getDefaultMapData() const override {
             return getStandardDefaultMapData(babelwires::MapEntryData::Kind::AllToSame);
@@ -58,39 +57,5 @@ void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogge
                                                seqwires::TrackFeature& output) const {
     const babelwires::ProjectContext& context = babelwires::RootFeature::getProjectContextAt(*m_chordTypeMapFeature);
 
-    const babelwires::MapData& chordTypeMapData = m_chordTypeMapFeature->get();
-    if (!chordTypeMapData.isValid(context.m_typeSystem)) {
-        throw babelwires::ModelException() << "The Chord Type Map is not valid.";
-    }
-
-    const ChordType& chordType =
-        context.m_typeSystem.getEntryByIdentifier(seqwires::ChordType::getThisIdentifier())->is<ChordType>();
-    const babelwires::EnumToValueValueAdapter<ChordType> chordTypeTargetAdapter{chordType};
-    babelwires::EnumSourceMapApplicator<ChordType, ChordType::Value> chordTypeApplicator(chordTypeMapData, chordType, chordTypeTargetAdapter);
-
-    const babelwires::MapData& pitchClassMapData = m_pitchClassMapFeature->get();
-    if (!pitchClassMapData.isValid(context.m_typeSystem)) {
-        throw babelwires::ModelException() << "The Pitch Class Map is not valid.";
-    }
-
-    const PitchClass& pitchClass =
-        context.m_typeSystem.getEntryByIdentifier(seqwires::PitchClass::getThisIdentifier())->is<PitchClass>();
-    const babelwires::EnumToValueValueAdapter<PitchClass> pitchClassTargetAdapter{pitchClass};
-    babelwires::EnumSourceMapApplicator<PitchClass, PitchClass::Value> pitchClassApplicator(pitchClassMapData, pitchClass, pitchClassTargetAdapter);
-
-    const Track& trackIn = input.get();
-    Track trackOut;
-
-    for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
-        if (it->as<ChordOnEvent>()) {
-            TrackEventHolder holder(*it);
-            Chord& chord = holder->is<ChordOnEvent>().m_chord;
-            chord.m_chordType = chordTypeApplicator[chord.m_chordType];
-            //chord.m_root = pitchClassApplicator[chord.m_root];
-            trackOut.addEvent(holder.release());
-        } else {
-            trackOut.addEvent(*it);
-        }
-    }
-    trackOut.setDuration(trackIn.getDuration());
+    output.set(std::make_unique<Track>(mapChordsFunction(context.m_typeSystem, input.get(), m_chordTypeMapFeature->get(), m_pitchClassMapFeature->get())));
 }

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -14,7 +14,7 @@
 #include <BabelWiresLib/Features/mapFeature.hpp>
 #include <BabelWiresLib/Features/rootFeature.hpp>
 #include <BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp>
-#include <BabelWiresLib/Maps/Helpers/unorderedMapApplicator.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumSourceMapApplicator.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 
@@ -50,9 +50,9 @@ void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogge
     const ChordType& chordType =
         context.m_typeSystem.getEntryByIdentifier(seqwires::ChordType::getThisIdentifier())->is<ChordType>();
 
-    const babelwires::EnumToIndexValueAdapter adapter{chordType};
+    const babelwires::EnumToValueValueAdapter<ChordType> targetAdapter{chordType};
 
-    babelwires::UnorderedMapApplicator<unsigned int, unsigned int> applicator(mapData, adapter, adapter);
+    babelwires::EnumSourceMapApplicator<ChordType, ChordType::Value> applicator(mapData, chordType, targetAdapter);
 
     const Track& trackIn = input.get();
     Track trackOut;
@@ -61,7 +61,7 @@ void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogge
         if (it->as<ChordOnEvent>()) {
             TrackEventHolder holder(*it);
             ChordType::Value& type = holder->is<ChordOnEvent>().m_chord.m_chordType;
-            type = static_cast<ChordType::Value>(applicator[static_cast<unsigned int>(type)]);
+            type = applicator[type];
             trackOut.addEvent(holder.release());
         } else {
             trackOut.addEvent(*it);

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -23,8 +23,7 @@
 namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
-            : babelwires::MapFeature(babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()},
-                                     babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()}) {}
+            : babelwires::MapFeature(seqwires::ChordType::getThisIdentifier(), seqwires::ChordType::getThisIdentifier()) {}
     };
 } // namespace
 

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -17,8 +17,8 @@ namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
             : babelwires::MapFeature(
-                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getRegisteredInstance()->getIdentifier()},
-                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getRegisteredInstance()->getIdentifier()}) {}
+                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getThisIdentifier()},
+                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getThisIdentifier()}) {}
     };
 } // namespace
 

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -22,7 +22,8 @@ namespace {
     };
 } // namespace
 
-seqwires::ChordMapProcessor::ChordMapProcessor() {
+seqwires::ChordMapProcessor::ChordMapProcessor(const babelwires::ProjectContext& context)
+    : babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature>(context) {
     m_chordTypeMapFeature = m_inputFeature->addField(
         std::make_unique<ChordTypeMap>(), REGISTERED_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"));
     addArrayFeature(REGISTERED_ID("Tracks", "Tracks", "24e56b0d-eb1e-4c93-97fd-ba4d639e112a"));

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -17,8 +17,8 @@ namespace {
     struct ChordTypeMap : babelwires::MapFeature {
         ChordTypeMap()
             : babelwires::MapFeature(
-                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getThisIdentifier()},
-                  babelwires::MapFeature::TypeSet{seqwires::ChordType::getThisIdentifier()}) {}
+                  babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()},
+                  babelwires::TypeIdSet{seqwires::ChordType::getThisIdentifier()}) {}
     };
 } // namespace
 

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -42,7 +42,7 @@ void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogge
                                                seqwires::TrackFeature& output) const {
     const babelwires::MapData& mapData = m_chordTypeMapFeature->get();
     const babelwires::ProjectContext& context = babelwires::RootFeature::getProjectContextAt(*m_chordTypeMapFeature);
-    if (!mapData.isValid(context)) {
+    if (!mapData.isValid(context.m_typeSystem)) {
         throw babelwires::ModelException() << "The Map is not valid.";
     }
 

--- a/SeqWiresLib/Processors/chordMapProcessor.hpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.hpp
@@ -1,0 +1,31 @@
+/**
+ * Processor which applies a map to chord events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include "SeqWiresLib/Features/trackFeature.hpp"
+
+#include "BabelWiresLib/Processors/parallelProcessor.hpp"
+
+namespace babelwires { class MapFeature; }
+
+namespace seqwires {
+
+    class ChordMapProcessor : public babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature> {
+      public:
+        ChordMapProcessor();
+
+        void processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const override;
+
+        struct Factory : public babelwires::CommonProcessorFactory<ChordMapProcessor> {
+            Factory();
+        };
+
+      private:
+        babelwires::MapFeature* m_chordTypeMapFeature;
+    };
+} // namespace seqwires

--- a/SeqWiresLib/Processors/chordMapProcessor.hpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.hpp
@@ -27,5 +27,6 @@ namespace seqwires {
 
       private:
         babelwires::MapFeature* m_chordTypeMapFeature;
+        babelwires::MapFeature* m_pitchClassMapFeature;
     };
 } // namespace seqwires

--- a/SeqWiresLib/Processors/chordMapProcessor.hpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.hpp
@@ -17,7 +17,7 @@ namespace seqwires {
 
     class ChordMapProcessor : public babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature> {
       public:
-        ChordMapProcessor();
+        ChordMapProcessor(const babelwires::ProjectContext& context);
 
         void processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const override;
 

--- a/SeqWiresLib/Processors/excerptProcessor.cpp
+++ b/SeqWiresLib/Processors/excerptProcessor.cpp
@@ -6,7 +6,11 @@
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "SeqWiresLib/Processors/excerptProcessor.hpp"
+<<<<<<< HEAD
 #include "SeqWiresLib/Features/trackFeature.hpp"
+=======
+
+>>>>>>> 02d1df7 (Add sketch of ChordMapProcessor)
 #include "SeqWiresLib/Functions/excerptFunction.hpp"
 #include "SeqWiresLib/Features/durationFeature.hpp"
 
@@ -17,6 +21,7 @@
 
 #include "Common/Identifiers/registeredIdentifier.hpp"
 
+<<<<<<< HEAD
 namespace {
     using ExcerptArrayFeature =
         babelwires::HasStaticSizeRange<babelwires::StandardArrayFeature<seqwires::TrackFeature>, 1, 16>;
@@ -24,6 +29,9 @@ namespace {
 
 seqwires::ExcerptProcessor::ExcerptProcessor(const babelwires::ProjectContext& projectContext)
 : babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature>(projectContext) {
+=======
+seqwires::ExcerptProcessor::ExcerptProcessor() {
+>>>>>>> 02d1df7 (Add sketch of ChordMapProcessor)
     m_start = m_inputFeature->addField(std::make_unique<DurationFeature>(),
                                        REGISTERED_ID("Start", "Start", "4b95f5db-a542-4660-a8db-97d3a5f831ca"));
     m_duration = m_inputFeature->addField(std::make_unique<DurationFeature>(),

--- a/SeqWiresLib/Processors/excerptProcessor.cpp
+++ b/SeqWiresLib/Processors/excerptProcessor.cpp
@@ -1,18 +1,14 @@
 /**
- * A processor which extracts a section of sequence data from a track. 
- * 
+ * A processor which extracts a section of sequence data from a track.
+ *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "SeqWiresLib/Processors/excerptProcessor.hpp"
-<<<<<<< HEAD
-#include "SeqWiresLib/Features/trackFeature.hpp"
-=======
-
->>>>>>> 02d1df7 (Add sketch of ChordMapProcessor)
-#include "SeqWiresLib/Functions/excerptFunction.hpp"
 #include "SeqWiresLib/Features/durationFeature.hpp"
+#include "SeqWiresLib/Features/trackFeature.hpp"
+#include "SeqWiresLib/Functions/excerptFunction.hpp"
 
 #include "BabelWiresLib/Features/arrayFeature.hpp"
 #include "BabelWiresLib/Features/featureMixins.hpp"
@@ -21,17 +17,13 @@
 
 #include "Common/Identifiers/registeredIdentifier.hpp"
 
-<<<<<<< HEAD
 namespace {
     using ExcerptArrayFeature =
         babelwires::HasStaticSizeRange<babelwires::StandardArrayFeature<seqwires::TrackFeature>, 1, 16>;
 } // namespace
 
 seqwires::ExcerptProcessor::ExcerptProcessor(const babelwires::ProjectContext& projectContext)
-: babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature>(projectContext) {
-=======
-seqwires::ExcerptProcessor::ExcerptProcessor() {
->>>>>>> 02d1df7 (Add sketch of ChordMapProcessor)
+    : babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature>(projectContext) {
     m_start = m_inputFeature->addField(std::make_unique<DurationFeature>(),
                                        REGISTERED_ID("Start", "Start", "4b95f5db-a542-4660-a8db-97d3a5f831ca"));
     m_duration = m_inputFeature->addField(std::make_unique<DurationFeature>(),
@@ -42,8 +34,8 @@ seqwires::ExcerptProcessor::ExcerptProcessor() {
 seqwires::ExcerptProcessor::Factory::Factory()
     : CommonProcessorFactory(REGISTERED_LONGID("TrackExcerpt", "Excerpt", "83c74dba-7861-447c-9abb-0b4439061baf"), 1) {}
 
-void seqwires::ExcerptProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const {
+void seqwires::ExcerptProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input,
+                                              seqwires::TrackFeature& output) const {
     auto trackOut = getTrackExcerpt(input.get(), m_start->get(), m_duration->get());
     output.set(std::move(trackOut));
 }
-

--- a/SeqWiresLib/Tracks/chordEvents.cpp
+++ b/SeqWiresLib/Tracks/chordEvents.cpp
@@ -33,9 +33,9 @@ seqwires::TrackEvent::GroupingInfo seqwires::ChordOnEvent::getGroupingInfo() con
 void seqwires::ChordOnEvent::transpose(int pitchOffset) {
     assert(pitchOffset <= 127);
     assert(pitchOffset >= -127);
-    static_assert(NUM_PITCH_CLASSES == 12);
-    unsigned int rootPitch = (m_chord.m_root + 132 + pitchOffset) % 12;
-    m_chord.m_root = static_cast<PitchClass>(rootPitch);
+    static_assert(static_cast<unsigned int>(PitchClass::Value::NUM_VALUES) == 12);
+    unsigned int rootPitch = (static_cast<unsigned int>(m_chord.m_root) + 132 + pitchOffset) % 12;
+    m_chord.m_root = static_cast<PitchClass::Value>(rootPitch);
 }
 
 bool seqwires::ChordOffEvent::operator==(const TrackEvent& other) const {

--- a/SeqWiresLib/chord.cpp
+++ b/SeqWiresLib/chord.cpp
@@ -7,15 +7,7 @@
  **/
 #include "SeqWiresLib/chord.hpp"
 
-namespace {
+ENUM_DEFINE_ENUM_VALUE_SOURCE(CHORD_TYPE_VALUES);
 
-#define CHORD_TYPE_SELECT_SECOND_ARGUMENT(A, B, C) B,
-    const char* s_chordTypeNames[static_cast<std::uint8_t>(seqwires::ChordType::Value::NUM_CHORD_TYPES)] = {
-        CHORD_TYPE_VALUES(CHORD_TYPE_SELECT_SECOND_ARGUMENT)
-    };
-} // namespace
-
-
-std::string seqwires::chordTypeToString(ChordType::Value t) {
-    return s_chordTypeNames[static_cast<std::uint8_t>(t)];
-}
+seqwires::ChordType::ChordType()
+: RegisteredEnum<ChordType>(REGISTERED_LONGID("ChordType", "Chord Type", "c63ea174-1562-4cb5-a456-d6c0bd89e335"), 1, ENUM_IDENTIFIER_VECTOR(CHORD_TYPE_VALUES), 0) {}

--- a/SeqWiresLib/chord.cpp
+++ b/SeqWiresLib/chord.cpp
@@ -7,6 +7,8 @@
  **/
 #include "SeqWiresLib/chord.hpp"
 
+#include <Common/Identifiers/identifierRegistry.hpp>
+
 ENUM_DEFINE_ENUM_VALUE_SOURCE(CHORD_TYPE_VALUES);
 
 babelwires::LongIdentifier seqwires::ChordType::getThisIdentifier() {
@@ -14,4 +16,4 @@ babelwires::LongIdentifier seqwires::ChordType::getThisIdentifier() {
 }
 
 seqwires::ChordType::ChordType()
-: Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(CHORD_TYPE_VALUES), 0) {}
+    : Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(CHORD_TYPE_VALUES), 0) {}

--- a/SeqWiresLib/chord.cpp
+++ b/SeqWiresLib/chord.cpp
@@ -9,5 +9,9 @@
 
 ENUM_DEFINE_ENUM_VALUE_SOURCE(CHORD_TYPE_VALUES);
 
+babelwires::LongIdentifier seqwires::ChordType::getThisIdentifier() {
+    return REGISTERED_LONGID("ChordType", "Chord Type", "c63ea174-1562-4cb5-a456-d6c0bd89e335");
+}
+
 seqwires::ChordType::ChordType()
-: RegisteredEnum<ChordType>(REGISTERED_LONGID("ChordType", "Chord Type", "c63ea174-1562-4cb5-a456-d6c0bd89e335"), 1, ENUM_IDENTIFIER_VECTOR(CHORD_TYPE_VALUES), 0) {}
+: Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(CHORD_TYPE_VALUES), 0) {}

--- a/SeqWiresLib/chord.hpp
+++ b/SeqWiresLib/chord.hpp
@@ -16,38 +16,38 @@
 // TODO Consider using \u266d (flat) and \u266f (sharp) in names.
 // TODO Not in XF spec v2.01 but available on more recent keyboards: b5, M7b5, mM7b5
 #define CHORD_TYPE_VALUES(X)                                                                                           \
-    X(M, "Maj", "1ef34c5c-e8d4-4cac-b189-e4ac2fffefd4")                                                              \
-    X(M6, "Maj6", "b8290240-fce4-4747-b9e4-07132222d0d0")                                                            \
-    X(M7, "Maj7", "5e1563bc-5fe8-40e5-977c-e33f9620a129")                                                            \
-    X(M7s11, "Maj7(#11)", "b7b5fa80-1376-408d-baf5-fab17a59b752")                                                     \
-    X(M9, "Maj(9)", "ab7816b3-970d-4c94-ba4c-04c28994729b")                                                          \
-    X(M7_9, "Maj7(9)", "ceba875d-d854-4c51-96ee-bf3cdbd3cb57")                                                        \
-    X(M6_9, "Maj6(9)", "eeb85cec-cb05-4474-b33c-c48e91cf9cca")                                                        \
+    X(M, "Maj", "1ef34c5c-e8d4-4cac-b189-e4ac2fffefd4")                                                                \
+    X(M6, "Maj6", "b8290240-fce4-4747-b9e4-07132222d0d0")                                                              \
+    X(M7, "Maj7", "5e1563bc-5fe8-40e5-977c-e33f9620a129")                                                              \
+    X(M7s11, "Maj7(#11)", "b7b5fa80-1376-408d-baf5-fab17a59b752")                                                      \
+    X(M9, "Maj(9)", "ab7816b3-970d-4c94-ba4c-04c28994729b")                                                            \
+    X(M7_9, "Maj7(9)", "ceba875d-d854-4c51-96ee-bf3cdbd3cb57")                                                         \
+    X(M6_9, "Maj6(9)", "eeb85cec-cb05-4474-b33c-c48e91cf9cca")                                                         \
     X(aug, "aug", "430cf87e-5e5f-4075-b4fa-bee132085f8b")                                                              \
-    X(m, "min", "59870eb3-9bb9-459e-8f81-601dd2c4d1f4")                                                              \
-    X(m6, "min6", "1f1d80ea-f34a-4bc6-a3ec-0984088a502a")                                                            \
-    X(m7, "min7", "d7d0154d-799f-4f96-afaf-23cda7de5b20")                                                            \
-    X(m7b5, "min7b5", "7fa7e272-25f9-4cc7-afdd-0c4f2dfed16b")                                                        \
-    X(m9, "min(9)", "7c12b85b-e490-420f-97de-dad20d31082c")                                                          \
-    X(m7_9, "min7(9)", "82258e7a-49cd-40a1-bf02-069c3cb5875a")                                                        \
+    X(m, "min", "59870eb3-9bb9-459e-8f81-601dd2c4d1f4")                                                                \
+    X(m6, "min6", "1f1d80ea-f34a-4bc6-a3ec-0984088a502a")                                                              \
+    X(m7, "min7", "d7d0154d-799f-4f96-afaf-23cda7de5b20")                                                              \
+    X(m7b5, "min7b5", "7fa7e272-25f9-4cc7-afdd-0c4f2dfed16b")                                                          \
+    X(m9, "min(9)", "7c12b85b-e490-420f-97de-dad20d31082c")                                                            \
+    X(m7_9, "min7(9)", "82258e7a-49cd-40a1-bf02-069c3cb5875a")                                                         \
     X(m7_11, "min7(11)", "a3b6be34-a1f9-4046-8962-a264b335b124")                                                       \
-    X(mM7, "minMaj7", "1fd06260-acbf-48bf-821c-b9b9d04aa8f3")                                                        \
-    X(mM7_9, "minMaj7(9)", "7babdce4-bf2c-4230-84bd-71c10aecb936")                                                    \
+    X(mM7, "minMaj7", "1fd06260-acbf-48bf-821c-b9b9d04aa8f3")                                                          \
+    X(mM7_9, "minMaj7(9)", "7babdce4-bf2c-4230-84bd-71c10aecb936")                                                     \
     X(dim, "dim", "f95f1002-53e8-4c69-a73d-e51665f713ca")                                                              \
     X(dim7, "dim7", "58bbfa30-d398-4f32-a471-6f839d268679")                                                            \
-    X(_7, "7th", "0cfbeb19-5df4-4670-9b1b-9b91fae9d57e")                                                             \
+    X(_7, "7th", "0cfbeb19-5df4-4670-9b1b-9b91fae9d57e")                                                               \
     X(_7sus4, "7sus4", "2597226d-7c9e-4fdf-b9fc-f3bdb5c47559")                                                         \
     X(_7b5, "7b5", "c2577a55-1ad1-486c-b219-5551c96269e6")                                                             \
     X(_79, "7(9)", "c5325da7-1b80-40a7-ab08-ab9c6a38102b")                                                             \
     X(_7s11, "7(#11)", "047a442a-aace-42ab-8902-ad3d5e3f2b41")                                                         \
-    X(_7_13, "7(13)", "b5662a4f-02a2-4230-991b-9ce9e5fb72a9")                                                           \
+    X(_7_13, "7(13)", "b5662a4f-02a2-4230-991b-9ce9e5fb72a9")                                                          \
     X(_7b9, "7(b9)", "980802bb-eada-4985-9458-f7715cb0ef83")                                                           \
     X(_7b13, "7(b13)", "1b369c34-2243-464a-8d4b-92258216be22")                                                         \
     X(_7s9, "7(#9)", "d5c917b5-079b-487b-ac0e-ceb33bed5fd6")                                                           \
     X(Mj7aug, "Maj7aug", "8f6b9f0a-9ce5-4b62-9a04-23610f7c7781")                                                       \
     X(_7aug, "7aug", "3c848378-1755-4788-bb8c-3f5c49dbcb47")                                                           \
-    X(_1p8, "1+8", "63f443e4-93d5-4609-b91a-5a6491ac19be")                                                            \
-    X(_1p5, "1+5", "a513bc99-e978-4699-bc7c-7e30d71f33d0")                                                            \
+    X(_1p8, "1+8", "63f443e4-93d5-4609-b91a-5a6491ac19be")                                                             \
+    X(_1p5, "1+5", "a513bc99-e978-4699-bc7c-7e30d71f33d0")                                                             \
     X(sus4, "sus4", "ce218a4b-4600-47de-8a77-45a490457ff4")                                                            \
     X(_1p2p5, "1+2+5", "28875d31-45c8-488f-9cc3-9172c0ad7929")
 // I'm guessing the "cc" XF value means "cancel chord", so it doesn't need to be represented.
@@ -62,7 +62,7 @@ namespace seqwires {
 
     /// Carries the enum of chord types.
     class ChordType : public babelwires::Enum {
-    public:
+      public:
         ChordType();
 
         static babelwires::LongIdentifier getThisIdentifier();
@@ -76,13 +76,9 @@ namespace seqwires {
         PitchClass m_root = seqwires::PITCH_CLASS_C;
         ChordType::Value m_chordType = seqwires::ChordType::Value::NotAValue;
 
-        bool operator==(Chord other) const {
-            return (m_root == other.m_root) && (m_chordType == other.m_chordType);
-        }
-        
-        bool operator!=(Chord other) const {
-            return (m_root != other.m_root) || (m_chordType != other.m_chordType);
-        }
+        bool operator==(Chord other) const { return (m_root == other.m_root) && (m_chordType == other.m_chordType); }
+
+        bool operator!=(Chord other) const { return (m_root != other.m_root) || (m_chordType != other.m_chordType); }
     };
 
 } // namespace seqwires

--- a/SeqWiresLib/chord.hpp
+++ b/SeqWiresLib/chord.hpp
@@ -11,7 +11,6 @@
 
 #include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
 
-/// Use uuids, etc, as for Enums, since it is very likely I will add an Enum for this.
 /// These match the "Chord type" values from the XF Format Specifications v2.01
 // TODO Consider using \u266d (flat) and \u266f (sharp) in names.
 // TODO Not in XF spec v2.01 but available on more recent keyboards: b5, M7b5, mM7b5
@@ -73,7 +72,7 @@ namespace seqwires {
     /// Defines the state of a chord event.
     // Note: This does not currently include all the data in a XF chord event.
     struct Chord {
-        PitchClass m_root = seqwires::PITCH_CLASS_C;
+        PitchClass::Value m_root = seqwires::PitchClass::Value::C;
         ChordType::Value m_chordType = seqwires::ChordType::Value::NotAValue;
 
         bool operator==(Chord other) const { return (m_root == other.m_root) && (m_chordType == other.m_chordType); }

--- a/SeqWiresLib/chord.hpp
+++ b/SeqWiresLib/chord.hpp
@@ -7,8 +7,9 @@
  **/
 #pragma once
 
-#include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
 #include "SeqWiresLib/musicTypes.hpp"
+
+#include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
 
 /// Use uuids, etc, as for Enums, since it is very likely I will add an Enum for this.
 /// These match the "Chord type" values from the XF Format Specifications v2.01
@@ -60,22 +61,18 @@ namespace seqwires {
     typedef babelwires::Byte Velocity;
 
     /// Carries the enum of chord types.
-    /// This can become an "Enum" when needed.
-    class ChordType {
+    class ChordType : public babelwires::RegisteredEnum<ChordType> {
     public:
-        enum class Value : std::uint8_t {
-            CHORD_TYPE_VALUES(CHORD_TYPE_SELECT_FIRST_ARGUMENT) NotAChord,
-            NUM_CHORD_TYPES = NotAChord
-        };
-    };
+        ChordType();
 
-    std::string chordTypeToString(ChordType::Value t);
+        ENUM_DEFINE_CPP_ENUM(CHORD_TYPE_VALUES);
+    };
 
     /// Defines the state of a chord event.
     // Note: This does not currently include all the data in a XF chord event.
     struct Chord {
         PitchClass m_root = seqwires::PITCH_CLASS_C;
-        ChordType::Value m_chordType = seqwires::ChordType::Value::NotAChord;
+        ChordType::Value m_chordType = seqwires::ChordType::Value::NotAValue;
 
         bool operator==(Chord other) const {
             return (m_root == other.m_root) && (m_chordType == other.m_chordType);

--- a/SeqWiresLib/chord.hpp
+++ b/SeqWiresLib/chord.hpp
@@ -61,9 +61,11 @@ namespace seqwires {
     typedef babelwires::Byte Velocity;
 
     /// Carries the enum of chord types.
-    class ChordType : public babelwires::RegisteredEnum<ChordType> {
+    class ChordType : public babelwires::Enum {
     public:
         ChordType();
+
+        static babelwires::LongIdentifier getThisIdentifier();
 
         ENUM_DEFINE_CPP_ENUM(CHORD_TYPE_VALUES);
     };

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -10,7 +10,7 @@
 #include "BabelWiresLib/Processors/processorFactory.hpp"
 #include "BabelWiresLib/Processors/processorFactoryRegistry.hpp"
 #include "BabelWiresLib/Project/projectContext.hpp"
-#include "BabelWiresLib/Enums/enum.hpp"
+#include "BabelWiresLib/TypeSystem/typeSystem.hpp"
 
 #include "SeqWiresLib/Processors/excerptProcessor.hpp"
 #include "SeqWiresLib/Processors/concatenateProcessor.hpp"
@@ -27,8 +27,8 @@
 #include "SeqWiresLib/chord.hpp"
 
 void seqwires::registerLib(babelwires::ProjectContext& context) {
-    context.m_enumRegistry.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
-    context.m_enumRegistry.addEntry(std::make_unique<ChordType>());
+    context.m_typeSystem.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
+    context.m_typeSystem.addEntry(std::make_unique<ChordType>());
     
     context.m_processorReg.addEntry(std::make_unique<ChordMapProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ConcatenateProcessor::Factory>());

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -21,6 +21,7 @@
 #include "SeqWiresLib/Processors/splitAtPitchProcessor.hpp"
 #include "SeqWiresLib/Processors/transposeProcessor.hpp"
 #include "SeqWiresLib/Processors/chordsFromNotesProcessor.hpp"
+#include "SeqWiresLib/Processors/chordMapProcessor.hpp"
 
 #include "SeqWiresLib/Functions/monophonicSubtracksFunction.hpp"
 
@@ -28,6 +29,7 @@
 void seqwires::registerLib(babelwires::ProjectContext& context) {
     context.m_enumRegistry.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
 
+    context.m_processorReg.addEntry(std::make_unique<ChordMapProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ConcatenateProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ExcerptProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<MergeProcessor::Factory>());

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -24,11 +24,12 @@
 #include "SeqWiresLib/Processors/chordMapProcessor.hpp"
 
 #include "SeqWiresLib/Functions/monophonicSubtracksFunction.hpp"
-
+#include "SeqWiresLib/chord.hpp"
 
 void seqwires::registerLib(babelwires::ProjectContext& context) {
     context.m_enumRegistry.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
-
+    context.m_enumRegistry.addEntry(std::make_unique<ChordType>());
+    
     context.m_processorReg.addEntry(std::make_unique<ChordMapProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ConcatenateProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ExcerptProcessor::Factory>());

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -25,10 +25,12 @@
 
 #include "SeqWiresLib/Functions/monophonicSubtracksFunction.hpp"
 #include "SeqWiresLib/chord.hpp"
+#include "SeqWiresLib/pitchClass.hpp"
 
 void seqwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
     context.m_typeSystem.addEntry(std::make_unique<ChordType>());
+    context.m_typeSystem.addEntry(std::make_unique<PitchClass>());
     
     context.m_processorReg.addEntry(std::make_unique<ChordMapProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<ConcatenateProcessor::Factory>());

--- a/SeqWiresLib/musicTypes.cpp
+++ b/SeqWiresLib/musicTypes.cpp
@@ -14,19 +14,12 @@
 #include <charconv>
 #include <cassert>
 
-
-namespace {
-    const char* s_pitchClassNames[seqwires::NUM_PITCH_CLASSES] = {"C",  "C#", "D",  "D#", "E",  "F",
-                                                                  "F#", "G",  "G#", "A",  "A#", "B"};
-} // namespace
-
-
 std::string seqwires::pitchToString(Pitch p) {
     const int pitchClass = p % 12;
     const int octave = (p / 12) - 1;
 
     std::ostringstream stringOut;
-    stringOut << s_pitchClassNames[pitchClass] << octave;
+    stringOut << PitchClass::valueToString(static_cast<PitchClass::Value>(pitchClass)) << octave;
 
     return stringOut.str();
 }
@@ -114,10 +107,6 @@ std::string seqwires::durationToString(ModelDuration d) {
     return stringOut.str();
 }
 
-std::string seqwires::pitchClassToString(PitchClass p) {
-    return s_pitchClassNames[p];
-}
-
-seqwires::PitchClass seqwires::pitchToPitchClass(seqwires::Pitch p) {
-    return static_cast<seqwires::PitchClass>(p % 12);
+seqwires::PitchClass::Value seqwires::pitchToPitchClass(seqwires::Pitch p) {
+    return static_cast<seqwires::PitchClass::Value>(p % 12);
 }

--- a/SeqWiresLib/musicTypes.hpp
+++ b/SeqWiresLib/musicTypes.hpp
@@ -9,8 +9,6 @@
 
 #include <SeqWiresLib/pitchClass.hpp>
 
-#include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
-
 #include "Common/Math/rational.hpp"
 #include "Common/types.hpp"
 

--- a/SeqWiresLib/musicTypes.hpp
+++ b/SeqWiresLib/musicTypes.hpp
@@ -7,12 +7,15 @@
  **/
 #pragma once
 
+#include <SeqWiresLib/pitchClass.hpp>
+
 #include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
+
 #include "Common/Math/rational.hpp"
 #include "Common/types.hpp"
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace seqwires {
 
@@ -20,27 +23,7 @@ namespace seqwires {
     typedef babelwires::Byte Pitch;
     typedef babelwires::Byte Velocity;
 
-    /// Note: Not trying to match the representation from XF, because I don't currently know how to transpose those
-    /// values.
-    enum PitchClass : std::uint8_t {
-        PITCH_CLASS_C,
-        PITCH_CLASS_C_SHARP,
-        PITCH_CLASS_D,
-        PITCH_CLASS_D_SHARP,
-        PITCH_CLASS_E,
-        PITCH_CLASS_F,
-        PITCH_CLASS_F_SHARP,
-        PITCH_CLASS_G,
-        PITCH_CLASS_G_SHARP,
-        PITCH_CLASS_A,
-        PITCH_CLASS_A_SHARP,
-        PITCH_CLASS_B,
-
-        NUM_PITCH_CLASSES
-    };
-
-    std::string pitchClassToString(PitchClass p);
-    PitchClass pitchToPitchClass(Pitch p);
+    PitchClass::Value pitchToPitchClass(Pitch p);
 
     std::string pitchToString(Pitch p);
     Pitch stringToPitch(std::string_view s);

--- a/SeqWiresLib/pitchClass.cpp
+++ b/SeqWiresLib/pitchClass.cpp
@@ -1,0 +1,31 @@
+/**
+ * Defines a data type for pitch class.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include "SeqWiresLib/pitchClass.hpp"
+
+#include <Common/Identifiers/identifierRegistry.hpp>
+
+ENUM_DEFINE_ENUM_VALUE_SOURCE(PITCH_CLASS_VALUES);
+
+babelwires::LongIdentifier seqwires::PitchClass::getThisIdentifier() {
+    return REGISTERED_LONGID("PitchClass", "Pitch Class", "0c7fed24-9923-42d3-9ad1-5879bf1c8af6");
+}
+
+seqwires::PitchClass::PitchClass()
+    : Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(PITCH_CLASS_VALUES), 0) {}
+
+#define JUST_NAMES(A, B, C) B, 
+
+namespace {
+    const char* s_pitchClassNames[static_cast<unsigned int>(seqwires::PitchClass::Value::NUM_VALUES)] = {
+        PITCH_CLASS_VALUES(JUST_NAMES)
+    };
+} // namespace
+
+std::string seqwires::PitchClass::valueToString(PitchClass::Value p) {
+    return s_pitchClassNames[static_cast<unsigned int>(p)];
+}

--- a/SeqWiresLib/pitchClass.hpp
+++ b/SeqWiresLib/pitchClass.hpp
@@ -1,0 +1,46 @@
+/**
+ * Defines a data type for pitch class.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include "BabelWiresLib/Enums/enumWithCppEnum.hpp"
+#include "Common/Math/rational.hpp"
+#include "Common/types.hpp"
+
+#include <cstdint>
+#include <string>
+
+/// Note: Not trying to match the representation from XF, because I don't currently know how to transpose those
+/// values.
+#define PITCH_CLASS_VALUES(X)                                                                                          \
+    X(C, "C", "7484e798-52b4-42d0-a521-6dc31e9c3bea")                                                                  \
+    X(CSharp, "C#", "2ed22c5e-cb89-4791-b689-f6b301f7679f")                                                            \
+    X(D, "D", "9710dcc6-a644-4f28-ac6b-975bf656a004")                                                                  \
+    X(DSharp, "D#", "0279e570-3a6b-456a-b20e-38aab3ebfd3f")                                                            \
+    X(E, "E", "c4ee1866-976a-4842-b24c-82d753820a82")                                                                  \
+    X(F, "F", "4a7fd0f1-914e-45ef-8887-b86a0bc23bd2")                                                                  \
+    X(FSharp, "F#", "240d9d71-8dd7-4af1-89c8-f15d7a4ac837")                                                            \
+    X(G, "G", "ed4c9566-3464-47e4-b3f2-fc118efba774")                                                                  \
+    X(GSharp, "G#", "b0a9cf82-dc9c-4a7e-a38b-06cff90cadb7")                                                            \
+    X(A, "A", "de1a1f2c-6bda-4469-a66d-2962c28d2a08")                                                                  \
+    X(ASharp, "A#", "0af2d2b4-c553-4f99-8635-906753824c98")                                                            \
+    X(B, "B", "ddca8184-107f-463e-adc4-73ced59bb76c")
+
+namespace seqwires {
+
+    class PitchClass : public babelwires::Enum {
+      public:
+        PitchClass();
+
+        static babelwires::LongIdentifier getThisIdentifier();
+
+        ENUM_DEFINE_CPP_ENUM(PITCH_CLASS_VALUES);
+
+        static std::string valueToString(Value p);
+    };
+
+} // namespace seqwires

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,9 @@ Also see [TODO.md in BabelWires](https://github.com/Malcohol/BabelWires/blob/mai
 
 SeqWires:
 * Support other formats
+* Improved handling of event truncation: 
+  - Use new group events to denote truncated end and start. 
+  - When truncated end meets truncated start, act as though event was not truncated.
 
 Seq2tape:
 * Proper plugin initialization for Seq2tape

--- a/Tests/SeqWiresLib/CMakeLists.txt
+++ b/Tests/SeqWiresLib/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET( SEQUENCELIB_TESTS_SRCS
       seqWiresLibTests.cpp
+      chordMapProcessorTest.cpp
       chordsFromNotesProcessorTest.cpp
       concatenateProcessorTest.cpp
       excerptProcessorTest.cpp

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <SeqWiresLib/Functions/mapChordsFunction.hpp>
+#include <SeqWiresLib/Processors/chordMapProcessor.hpp>
+#include <SeqWiresLib/Tracks/chordEvents.hpp>
+#include <SeqWiresLib/Tracks/track.hpp>
+#include <SeqWiresLib/chord.hpp>
+
+#include <BabelWiresLib/Maps/MapEntries/allToSameFallbackMapEntryData.hpp>
+#include <BabelWiresLib/Maps/MapEntries/oneToOneMapEntryData.hpp>
+#include <BabelWiresLib/Maps/mapData.hpp>
+#include <BabelWiresLib/TypeSystem/enumValue.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+#include <BabelWiresLib/Features/mapFeature.hpp>
+
+#include <Tests/BabelWiresLib/TestUtils/testEnvironment.hpp>
+#include <Tests/TestUtils/seqTestUtils.hpp>
+#include <Tests/TestUtils/testLog.hpp>
+
+namespace {
+    babelwires::MapData getTestChordTypeMap(const babelwires::TypeSystem& typeSystem) {
+        const seqwires::ChordType& chordTypeEnum =
+            typeSystem.getRegisteredEntry(seqwires::ChordType::getThisIdentifier()).is<seqwires::ChordType>();
+
+        babelwires::MapData chordTypeMap;
+        chordTypeMap.setSourceTypeId(seqwires::ChordType::getThisIdentifier());
+        chordTypeMap.setTargetTypeId(seqwires::ChordType::getThisIdentifier());
+
+        babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::ChordType::getThisIdentifier(),
+                                                         seqwires::ChordType::getThisIdentifier());
+
+        babelwires::EnumValue chordTypeSourceValue;
+        chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
+
+        babelwires::EnumValue chordTypeTargetValue;
+        chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
+
+        chordTypeMaplet.setSourceValue(chordTypeSourceValue.clone());
+        chordTypeMaplet.setTargetValue(chordTypeTargetValue.clone());
+
+        chordTypeMap.emplaceBack(chordTypeMaplet.clone());
+        chordTypeMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
+        return chordTypeMap;
+    }
+
+    babelwires::MapData getTestPitchClassMap(const babelwires::TypeSystem& typeSystem) {
+        const seqwires::PitchClass& pitchClassEnum =
+            typeSystem.getRegisteredEntry(seqwires::PitchClass::getThisIdentifier()).is<seqwires::PitchClass>();
+
+        babelwires::MapData pitchClassMap;
+        pitchClassMap.setSourceTypeId(seqwires::PitchClass::getThisIdentifier());
+        pitchClassMap.setTargetTypeId(seqwires::PitchClass::getThisIdentifier());
+
+        babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::PitchClass::getThisIdentifier(),
+                                                         seqwires::PitchClass::getThisIdentifier());
+
+        babelwires::EnumValue pitchClassSourceValue;
+        pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
+
+        babelwires::EnumValue pitchClassTargetValue;
+        pitchClassTargetValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
+
+        chordTypeMaplet.setSourceValue(pitchClassSourceValue.clone());
+        chordTypeMaplet.setTargetValue(pitchClassTargetValue.clone());
+
+        pitchClassMap.emplaceBack(chordTypeMaplet.clone());
+        pitchClassMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
+        return pitchClassMap;
+    }
+
+    seqwires::Track getTestInputTrack() {
+        seqwires::Track track;
+
+        testUtils::addChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                            {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::M},
+                            {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
+                            {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
+                            track);
+
+        return track;
+    }
+
+    void testOutputTrack(const seqwires::Track& outputTrack) {
+        testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m7},
+                           {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
+                          outputTrack);
+    }
+} // namespace
+
+TEST(ChordMapProcessorTest, simpleFunction) {
+    testUtils::TestLog log;
+
+    babelwires::TypeSystem typeSystem;
+    typeSystem.addEntry(std::make_unique<seqwires::ChordType>());
+    typeSystem.addEntry(std::make_unique<seqwires::PitchClass>());
+
+    babelwires::MapData chordTypeMap = getTestChordTypeMap(typeSystem);
+    babelwires::MapData pitchClassMap = getTestPitchClassMap(typeSystem);
+
+    seqwires::Track inputTrack = getTestInputTrack();
+
+    seqwires::Track outputTrack = seqwires::mapChordsFunction(typeSystem, inputTrack, chordTypeMap, pitchClassMap);
+
+    testOutputTrack(outputTrack);
+    EXPECT_EQ(inputTrack.getDuration(), outputTrack.getDuration());
+}
+
+TEST(ChordMapProcessorTest, processor) {
+    testUtils::TestEnvironment testEnvironment;
+    testEnvironment.m_typeSystem.addEntry(std::make_unique<seqwires::ChordType>());
+    testEnvironment.m_typeSystem.addEntry(std::make_unique<seqwires::PitchClass>());
+
+    const seqwires::ChordType& chordTypeEnum =
+        testEnvironment.m_typeSystem.getRegisteredEntry(seqwires::ChordType::getThisIdentifier())
+            .is<seqwires::ChordType>();
+    const seqwires::PitchClass& pitchClassEnum =
+        testEnvironment.m_typeSystem.getRegisteredEntry(seqwires::PitchClass::getThisIdentifier())
+            .is<seqwires::PitchClass>();
+
+    seqwires::ChordMapProcessor processor(testEnvironment.m_projectContext);
+
+    processor.getInputFeature()->setToDefault();
+    processor.getOutputFeature()->setToDefault();
+
+    auto* chordTypeMapFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("TypMap")).as<babelwires::MapFeature>();
+    auto* pitchClassMapFeature = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("RtMap")).as<babelwires::MapFeature>();
+    auto* inputArray = processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    auto* outputArray = processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    ASSERT_NE(chordTypeMapFeature, nullptr);
+    ASSERT_NE(pitchClassMapFeature, nullptr);
+    ASSERT_NE(inputArray, nullptr);
+    ASSERT_NE(outputArray, nullptr);
+ 
+    EXPECT_EQ(inputArray->getNumFeatures(), 1);
+    EXPECT_EQ(outputArray->getNumFeatures(), 1);
+
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) { return outputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+
+    ASSERT_NE(getInputTrack(0), nullptr);
+    ASSERT_NE(getOutputTrack(0), nullptr);
+
+    chordTypeMapFeature->set(getTestChordTypeMap(testEnvironment.m_typeSystem));
+    pitchClassMapFeature->set(getTestPitchClassMap(testEnvironment.m_typeSystem));
+    getInputTrack(0)->set(getTestInputTrack());
+
+    processor.process(testEnvironment.m_log);
+
+    testOutputTrack(getOutputTrack(0)->get());
+}

--- a/Tests/SeqWiresLib/chordsFromNotesProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordsFromNotesProcessorTest.cpp
@@ -31,8 +31,8 @@ TEST(ChordsFromNotesTest, functionBasic) {
     seqwires::Track chordTrack = seqwires::chordsFromNotesFunction(track);
     EXPECT_EQ(chordTrack.getDuration(), 2);
 
-    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1},
-                                                        {seqwires::PITCH_CLASS_D, seqwires::ChordType::Value::m, 1}};
+    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1},
+                                                        {seqwires::PitchClass::Value::D, seqwires::ChordType::Value::m, 1}};
 
     testUtils::testChords(expectedChords, chordTrack);
 }
@@ -54,7 +54,7 @@ TEST(ChordsFromNotesTest, rootPitchClass) {
     std::vector<testUtils::ChordInfo> expectedChords;
     for (int o = 0; o < 10; ++o) {
         for (int pc = 0; pc < 12; ++pc) {
-            expectedChords.emplace_back(testUtils::ChordInfo{static_cast<seqwires::PitchClass>(pc), seqwires::ChordType::Value::M, 1, 1});
+            expectedChords.emplace_back(testUtils::ChordInfo{static_cast<seqwires::PitchClass::Value>(pc), seqwires::ChordType::Value::M, 1, 1});
         }
     }
 
@@ -78,8 +78,8 @@ TEST(ChordsFromNotesTest, functionChordToChord) {
     seqwires::Track chordTrack = seqwires::chordsFromNotesFunction(track);
     EXPECT_EQ(chordTrack.getDuration(), 2);
 
-    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1},
-                                                        {seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::m, 1}};
+    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1},
+                                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::Value::m, 1}};
 
     testUtils::testChords(expectedChords, chordTrack);
 }
@@ -114,9 +114,9 @@ TEST(ChordsFromNotesTest, majorInversions) {
     seqwires::Track chordTrack = seqwires::chordsFromNotesFunction(track);
     EXPECT_EQ(chordTrack.getDuration(), 5);
 
-    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1, 0},
-                                                        {seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1, 1},
-                                                        {seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1, 1}};
+    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1, 0},
+                                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1, 1},
+                                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1, 1}};
 
     testUtils::testChords(expectedChords, chordTrack);
 }
@@ -151,9 +151,9 @@ TEST(ChordsFromNotesTest, minorInversions) {
     seqwires::Track chordTrack = seqwires::chordsFromNotesFunction(track);
     EXPECT_EQ(chordTrack.getDuration(), 5);
 
-    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::m, 1, 0},
-                                                        {seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::m, 1, 1},
-                                                        {seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::m, 1, 1}};
+    std::vector<testUtils::ChordInfo> expectedChords = {{seqwires::PitchClass::Value::C, seqwires::ChordType::Value::m, 1, 0},
+                                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::Value::m, 1, 1},
+                                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::Value::m, 1, 1}};
 
     testUtils::testChords(expectedChords, chordTrack);
 }
@@ -362,7 +362,7 @@ TEST(ChordsFromNotesTest, schemeY) {
 
     std::vector<testUtils::ChordInfo> expectedChords;
     for (auto c : expectedChordType) {
-        expectedChords.emplace_back(testUtils::ChordInfo{PITCH_CLASS_C, c, 1, 1});
+        expectedChords.emplace_back(testUtils::ChordInfo{PitchClass::Value::C, c, 1, 1});
     }
 
     testUtils::testChords(expectedChords, chordTrack);
@@ -568,7 +568,7 @@ TEST(ChordsFromNotesTest, schemeR) {
 
     std::vector<testUtils::ChordInfo> expectedChords;
     for (auto c : expectedChordType) {
-        expectedChords.emplace_back(testUtils::ChordInfo{PITCH_CLASS_C, c, 1, 1});
+        expectedChords.emplace_back(testUtils::ChordInfo{PitchClass::Value::C, c, 1, 1});
     }
 
     testUtils::testChords(expectedChords, chordTrack);
@@ -666,7 +666,7 @@ TEST(ChordsFromNotesTest, schemeC) {
 
     std::vector<testUtils::ChordInfo> expectedChords;
     for (auto c : expectedChordType) {
-        expectedChords.emplace_back(testUtils::ChordInfo{PITCH_CLASS_C, c, 1, 1});
+        expectedChords.emplace_back(testUtils::ChordInfo{PitchClass::Value::C, c, 1, 1});
     }
 
     testUtils::testChords(expectedChords, chordTrack);
@@ -701,7 +701,7 @@ TEST(ChordsFromNotesTest, processor) {
 
     processor.process(testEnvironment.m_log);
 
-    testUtils::testChords({{seqwires::PITCH_CLASS_C, seqwires::ChordType::Value::M, 1}}, outputTrack->get());
+    testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::Value::M, 1}}, outputTrack->get());
 
     {
         seqwires::Track track;
@@ -716,5 +716,5 @@ TEST(ChordsFromNotesTest, processor) {
 
     processor.process(testEnvironment.m_log);
 
-    testUtils::testChords({{seqwires::PITCH_CLASS_D, seqwires::ChordType::Value::m, 1}}, outputTrack->get());
+    testUtils::testChords({{seqwires::PitchClass::Value::D, seqwires::ChordType::Value::m, 1}}, outputTrack->get());
 }

--- a/Tests/SeqWiresLib/monophonicSubtracksProcessorTest.cpp
+++ b/Tests/SeqWiresLib/monophonicSubtracksProcessorTest.cpp
@@ -17,7 +17,7 @@ namespace {
         track.addEvent(seqwires::NoteOnEvent{0, 72});
         track.addEvent(seqwires::NoteOnEvent{0, 48});
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 72});
         track.addEvent(seqwires::NoteOffEvent{0, 48});
         track.addEvent(seqwires::NoteOnEvent{0, 74});
@@ -28,7 +28,7 @@ namespace {
         track.addEvent(seqwires::NoteOnEvent{0, 76});
         track.addEvent(seqwires::NoteOnEvent{0, 52});
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 76});
         track.addEvent(seqwires::NoteOffEvent{0, 52});
         track.addEvent(seqwires::NoteOnEvent{0, 77});
@@ -42,7 +42,7 @@ namespace {
     seqwires::Track getStaggeredPolyphonicTrack() {
         seqwires::Track track;
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}});
         track.addEvent(seqwires::NoteOnEvent{0, 48});
         track.addEvent(seqwires::NoteOnEvent{babelwires::Rational(1, 4), 60});
         track.addEvent(seqwires::NoteOnEvent{babelwires::Rational(1, 4), 72});
@@ -54,7 +54,7 @@ namespace {
         track.addEvent(seqwires::NoteOnEvent{0, 74});
         track.addEvent(seqwires::ChordOffEvent{0});
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 50});
         track.addEvent(seqwires::NoteOnEvent{0, 48});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 62});
@@ -71,7 +71,7 @@ namespace {
     seqwires::Track getStaggeredPolyphonicTrack2() {
         seqwires::Track track;
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}});
         track.addEvent(seqwires::NoteOnEvent{0, 72});
         track.addEvent(seqwires::NoteOnEvent{babelwires::Rational(1, 4), 60});
         track.addEvent(seqwires::NoteOnEvent{babelwires::Rational(1, 4), 48});
@@ -83,7 +83,7 @@ namespace {
         track.addEvent(seqwires::NoteOnEvent{0, 50});
         track.addEvent(seqwires::ChordOffEvent{0});
         track.addEvent(
-            seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}});
+            seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 74});
         track.addEvent(seqwires::NoteOnEvent{0, 72});
         track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 62});
@@ -111,8 +111,8 @@ TEST(MonophonicSubtracksProcessorTest, simpleFunction) {
 
     testUtils::testSimpleNotes({72, 74, 76, 77}, result.m_noteTracks[0]);
     testUtils::testSimpleNotes({48, 50, 52, 53}, result.m_noteTracks[1]);
-    testUtils::testChords({{seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-                           {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+    testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                           result.m_other);
 }
 
@@ -129,8 +129,8 @@ TEST(MonophonicSubtracksProcessorTest, FunctionLower) {
 
     testUtils::testSimpleNotes({72, 74, 76, 77}, result.m_noteTracks[1]);
     testUtils::testSimpleNotes({48, 50, 52, 53}, result.m_noteTracks[0]);
-    testUtils::testChords({{seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-                           {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+    testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                           result.m_other);
 }
 
@@ -149,8 +149,8 @@ TEST(MonophonicSubtracksProcessorTest, redundantTracks) {
     testUtils::testSimpleNotes({72, 74, 76, 77}, result.m_noteTracks[0]);
     testUtils::testSimpleNotes({48, 50, 52, 53}, result.m_noteTracks[1]);
     EXPECT_EQ(result.m_noteTracks[2].getNumEvents(), 0);
-    testUtils::testChords({{seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-                           {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+    testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                           result.m_other);
 }
 
@@ -167,12 +167,12 @@ TEST(MonophonicSubtracksProcessorTest, eventToOther) {
     testUtils::testSimpleNotes({72, 74, 76, 77}, result.m_noteTracks[0]);
 
     const std::vector<seqwires::TrackEventHolder> expectedEvents = {
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}},
         seqwires::NoteOnEvent{0, 48},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 48},
         seqwires::NoteOnEvent{0, 50},
         seqwires::ChordOffEvent{babelwires::Rational(1, 4)},
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
         seqwires::NoteOffEvent{0, 50},
         seqwires::NoteOnEvent{0, 52},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 52},
@@ -205,11 +205,11 @@ TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictOneTrack) {
     testUtils::testNotesAndChords(monoEvents, result.m_noteTracks[0]);
 
     const std::vector<seqwires::TrackEventHolder> otherEvents = {
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}},
         seqwires::NoteOnEvent{babelwires::Rational(3, 4), 50},
         seqwires::NoteOnEvent{babelwires::Rational(1, 4), 62},
         seqwires::ChordOffEvent{babelwires::Rational(1, 4)},
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 50},
         seqwires::NoteOnEvent{0, 48},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 62},
@@ -251,10 +251,10 @@ TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictTwoTracks) {
     testUtils::testNotesAndChords(monoEvents1, result.m_noteTracks[1]);
 
     const std::vector<seqwires::TrackEventHolder> otherEvents = {
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}},
         seqwires::NoteOnEvent{babelwires::Rational(3, 4), 50},
         seqwires::ChordOffEvent{babelwires::Rational(1, 2)},
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 50},
         seqwires::NoteOnEvent{0, 48},
         seqwires::NoteOffEvent{babelwires::Rational(3, 4), 48},
@@ -286,11 +286,11 @@ TEST(MonophonicSubtracksProcessorTest, lowerPitchesEvictOneTrack) {
     testUtils::testNotesAndChords(monoEvents, result.m_noteTracks[0]);
 
     const std::vector<seqwires::TrackEventHolder> otherEvents = {
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}},
         seqwires::NoteOnEvent{babelwires::Rational(3, 4), 74},
         seqwires::NoteOnEvent{babelwires::Rational(1, 4), 62},
         seqwires::ChordOffEvent{babelwires::Rational(1, 4)},
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 74},
         seqwires::NoteOnEvent{0, 72},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 62},
@@ -332,10 +332,10 @@ TEST(MonophonicSubtracksProcessorTest, lowerPitchesEvictTwoTracks) {
     testUtils::testNotesAndChords(monoEvents1, result.m_noteTracks[1]);
 
     const std::vector<seqwires::TrackEventHolder> otherEvents = {
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}},
         seqwires::NoteOnEvent{babelwires::Rational(3, 4), 74},
         seqwires::ChordOffEvent{babelwires::Rational(1, 2)},
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
         seqwires::NoteOffEvent{babelwires::Rational(1, 4), 74},
         seqwires::NoteOnEvent{0, 72},
         seqwires::NoteOffEvent{babelwires::Rational(3, 4), 72},

--- a/Tests/SeqWiresLib/musicTypesTest.cpp
+++ b/Tests/SeqWiresLib/musicTypesTest.cpp
@@ -5,7 +5,7 @@
 #include "Common/exceptions.hpp"
 
 TEST(SeqWiresLib, enumNames) {
-    EXPECT_EQ(seqwires::pitchClassToString(seqwires::PITCH_CLASS_C), "C");
+    EXPECT_EQ(seqwires::PitchClass::valueToString(seqwires::PitchClass::Value::C), "C");
 
     EXPECT_EQ(seqwires::pitchToString(0), "C-1");
     EXPECT_EQ(seqwires::pitchToString(1), "C#-1");

--- a/Tests/SeqWiresLib/splitAtPitchProcessorTest.cpp
+++ b/Tests/SeqWiresLib/splitAtPitchProcessorTest.cpp
@@ -47,7 +47,7 @@ TEST(SplitAtPitchProcessorTest, aboveAndBelowSplit) {
     track.addEvent(seqwires::NoteOnEvent{0, 72});
     track.addEvent(seqwires::NoteOnEvent{0, 48});
     track.addEvent(
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M}});
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M}});
     track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 72});
     track.addEvent(seqwires::NoteOffEvent{0, 48});
     track.addEvent(seqwires::NoteOnEvent{0, 74});
@@ -58,7 +58,7 @@ TEST(SplitAtPitchProcessorTest, aboveAndBelowSplit) {
     track.addEvent(seqwires::NoteOnEvent{0, 76});
     track.addEvent(seqwires::NoteOnEvent{0, 52});
     track.addEvent(
-        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}});
+        seqwires::ChordOnEvent{0, {seqwires::PitchClass::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}});
     track.addEvent(seqwires::NoteOffEvent{babelwires::Rational(1, 4), 76});
     track.addEvent(seqwires::NoteOffEvent{0, 52});
     track.addEvent(seqwires::NoteOnEvent{0, 77});
@@ -74,8 +74,8 @@ TEST(SplitAtPitchProcessorTest, aboveAndBelowSplit) {
     EXPECT_EQ(result.m_equalOrAbove.getDuration(), 1);
     testUtils::testSimpleNotes({48, 50, 52, 53}, result.m_below);
     EXPECT_EQ(result.m_below.getDuration(), 1);
-    testUtils::testChords({{seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-                           {seqwires::PitchClass::PITCH_CLASS_D, seqwires::ChordType::ChordType::Value::m}},
+    testUtils::testChords({{seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+                           {seqwires::PitchClass::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                           result.m_other);
     EXPECT_EQ(result.m_other.getDuration(), 1);
 }

--- a/Tests/SeqWiresLib/transposeProcessorTest.cpp
+++ b/Tests/SeqWiresLib/transposeProcessorTest.cpp
@@ -67,19 +67,19 @@ TEST(TransposeProcessorTest, funcSimpleChordsZero) {
 
     // Some random chords.
     testUtils::addChords({
-        {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_E, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_G_SHARP, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_A, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::GSharp, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::aug},
         }, trackIn);
 
     auto trackOut = seqwires::transposeTrack(trackIn, 0);
 
     testUtils::testChords({
-        {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_E, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_G_SHARP, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_A, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::GSharp, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::aug},
         }, trackIn);
 }
 
@@ -88,19 +88,19 @@ TEST(TransposeProcessorTest, funcSimpleChordsPositive) {
 
     // Some random chords.
     testUtils::addChords({
-        {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_E, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_G_SHARP, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_B, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::GSharp, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::aug},
         }, trackIn);
 
     auto trackOut = seqwires::transposeTrack(trackIn, 1);
 
     testUtils::testChords({
-        {seqwires::PitchClass::PITCH_CLASS_C_SHARP, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_F, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_A, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::CSharp, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::F, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::aug},
         }, trackOut);
 }
 
@@ -109,19 +109,19 @@ TEST(TransposeProcessorTest, funcSimpleChordsNegative) {
 
     // Some random chords.
     testUtils::addChords({
-        {seqwires::PitchClass::PITCH_CLASS_C, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_E, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_G_SHARP, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_B, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::GSharp, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::aug},
         }, trackIn);
 
     auto trackOut = seqwires::transposeTrack(trackIn, -1);
 
     testUtils::testChords({
-        {seqwires::PitchClass::PITCH_CLASS_B, seqwires::ChordType::ChordType::Value::M},
-        {seqwires::PitchClass::PITCH_CLASS_D_SHARP, seqwires::ChordType::ChordType::Value::m},
-        {seqwires::PitchClass::PITCH_CLASS_G, seqwires::ChordType::ChordType::Value::dim},
-        {seqwires::PitchClass::PITCH_CLASS_A_SHARP, seqwires::ChordType::ChordType::Value::aug},
+        {seqwires::PitchClass::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::M},
+        {seqwires::PitchClass::PitchClass::Value::DSharp, seqwires::ChordType::ChordType::Value::m},
+        {seqwires::PitchClass::PitchClass::Value::G, seqwires::ChordType::ChordType::Value::dim},
+        {seqwires::PitchClass::PitchClass::Value::ASharp, seqwires::ChordType::ChordType::Value::aug},
         }, trackOut);
 }
 


### PR DESCRIPTION
Maps are needed to map between values in source and target types.

The ChordMapProcessor shows them in use.