### PR TITLE
Add percussionMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The result is like a simple [musical round](https://en.wikipedia.org/wiki/Round_
 
 ![Screenshot showing several nodes wired together](https://raw.githubusercontent.com/Malcohol/BabelWires/main/Docs/screenshot.png "An example SeqWires project")
 
-Here's a screenshot of the MapEditor defining a map between chord types:
+Here's a screenshot of the MapEditor defining a map between percussion instruments:
 
-![Screenshot showing the MapEditor](https://raw.githubusercontent.com/Malcohol/BabelWires/main/Docs/mapEditor.png "Screenshot of the MapEditor defining a map between chordTypes")
+![Screenshot showing the MapEditor](https://raw.githubusercontent.com/Malcohol/BabelWires/main/Docs/mapEditor.png "Screenshot of the MapEditor defining a map between percussion instruments")
 
 Right now, the supported formats are:
 * SMF (standard MIDI file)

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -8,6 +8,7 @@ SET( SEQWIRESLIB_SRCS
 	Processors/excerptProcessor.cpp
 	Processors/mergeProcessor.cpp
 	Processors/monophonicSubtracksProcessor.cpp
+	Processors/percussionMapProcessor.cpp
 	Processors/quantizeProcessor.cpp
 	Processors/repeatProcessor.cpp
 	Processors/silenceProcessor.cpp

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -30,6 +30,7 @@ SET( SEQWIRESLIB_SRCS
 	Tracks/track.cpp
 	chord.cpp
 	musicTypes.cpp
+	percussion.cpp
 	pitchClass.cpp
 	Utilities/monophonicNoteIterator.cpp
 	libRegistration.cpp

--- a/SeqWiresLib/CMakeLists.txt
+++ b/SeqWiresLib/CMakeLists.txt
@@ -18,6 +18,7 @@ SET( SEQWIRESLIB_SRCS
 	Functions/mapChordsFunction.cpp
 	Functions/excerptFunction.cpp
 	Functions/repeatFunction.cpp
+	Functions/percussionMapFunction.cpp
 	Functions/mergeFunction.cpp
 	Functions/monophonicSubtracksFunction.cpp
 	Functions/quantizeFunction.cpp

--- a/SeqWiresLib/Functions/percussionMapFunction.cpp
+++ b/SeqWiresLib/Functions/percussionMapFunction.cpp
@@ -1,0 +1,88 @@
+/**
+ * Function which applies maps to chord events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <SeqWiresLib/Functions/percussionMapFunction.hpp>
+
+#include <SeqWiresLib/Tracks/noteEvents.hpp>
+#include <SeqWiresLib/Tracks/trackEventHolder.hpp>
+#include <SeqWiresLib/percussion.hpp>
+
+#include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Features/modelExceptions.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumSourceMapApplicator.hpp>
+#include <BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+
+namespace {
+    struct PercussionToPitchValueAdapter {
+        babelwires::Enum m_percussionEnum;
+
+        seqwires::Pitch operator()(const babelwires::Value& value) const {
+            const auto& enumValue = value.is<babelwires::EnumValue>();
+            const unsigned int index = m_percussionEnum.getIndexFromIdentifier(enumValue.get());
+            const seqwires::Pitch pitch = seqwires::GM2Percussion::getPitchFromIndex(index);
+            return pitch;
+        }
+    };
+
+    using MapType = babelwires::EnumSourceMapApplicator<seqwires::GM2Percussion, seqwires::Pitch>;
+
+    bool mapPercussionEvent(const seqwires::GM2Percussion& percussionType, MapType& mapApplicator,
+                            seqwires::NoteEvent& noteEvent) {
+        const seqwires::Pitch originalPitch = noteEvent.getPitch();
+        seqwires::GM2Percussion::Value value;
+        if (percussionType.tryGetValueFromPitch(originalPitch, value)) {
+            const seqwires::Pitch newPitch = mapApplicator[value];
+            noteEvent.setPitch(newPitch);
+            return true;
+        }
+        // Not a known percussion event.
+        // TODO: Probably would be better to use default here.
+        return false;
+    }
+} // namespace
+
+seqwires::Track seqwires::mapPercussionFunction(const babelwires::TypeSystem& typeSystem, const Track& trackIn,
+                                                const babelwires::MapData& percussionMapData) {
+
+    if (!percussionMapData.isValid(typeSystem)) {
+        throw babelwires::ModelException() << "The Percussion Map is not valid.";
+    }
+    const GM2Percussion& percussionType =
+        typeSystem.getEntryByIdentifier(seqwires::GM2Percussion::getThisIdentifier())->is<GM2Percussion>();
+
+    PercussionToPitchValueAdapter targetAdapter{percussionType};
+    MapType mapApplicator(percussionMapData, percussionType, targetAdapter);
+
+    Track trackOut;
+    // If an event is dropped, then we need to carry its time forward for the next event.
+    ModelDuration timeFromDroppedEvent;
+
+    for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
+        const TrackEvent::GroupingInfo info = it->getGroupingInfo();
+        if (info.m_category == NoteEvent::s_noteEventCategory) {
+            TrackEventHolder holder(*it);
+            if (mapPercussionEvent(percussionType, mapApplicator, static_cast<NoteEvent&>(*holder))) {
+                holder->setTimeSinceLastEvent(holder->getTimeSinceLastEvent() + timeFromDroppedEvent);
+                timeFromDroppedEvent = 0;
+                trackOut.addEvent(holder.release());
+            } else {
+                timeFromDroppedEvent += it->getTimeSinceLastEvent();
+            }
+        } else if (timeFromDroppedEvent > 0) {
+            TrackEventHolder holder(*it);
+            holder->setTimeSinceLastEvent(holder->getTimeSinceLastEvent() + timeFromDroppedEvent);
+            timeFromDroppedEvent = 0;
+            trackOut.addEvent(holder.release());
+        } else {
+            trackOut.addEvent(*it);
+        }
+    }
+    trackOut.setDuration(trackIn.getDuration());
+
+    return trackOut;
+}

--- a/SeqWiresLib/Functions/percussionMapFunction.hpp
+++ b/SeqWiresLib/Functions/percussionMapFunction.hpp
@@ -1,0 +1,18 @@
+/**
+ * Function which maps notes events using a percussion map.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <SeqWiresLib/Tracks/track.hpp>
+
+namespace babelwires {
+    class MapData;
+    class TypeSystem;
+}
+
+namespace seqwires {
+    /// 
+    Track mapPercussionFunction(const babelwires::TypeSystem& typeSystem, const Track& sourceTrack, const babelwires::MapData& percussionMapData);
+}

--- a/SeqWiresLib/Processors/percussionMapProcessor.cpp
+++ b/SeqWiresLib/Processors/percussionMapProcessor.cpp
@@ -1,0 +1,48 @@
+/**
+ * Processor which applies a map to chord events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <SeqWiresLib/Processors/percussionMapProcessor.hpp>
+
+#include <SeqWiresLib/Functions/percussionMapFunction.hpp>
+#include <SeqWiresLib/percussion.hpp>
+
+#include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Features/rootFeature.hpp>
+#include <BabelWiresLib/Project/projectContext.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+
+#include <Common/Identifiers/registeredIdentifier.hpp>
+
+namespace {
+    struct PercussionTypeMap : babelwires::MapFeature {
+        PercussionTypeMap()
+            : babelwires::MapFeature(seqwires::GM2Percussion::getThisIdentifier(),
+                                     seqwires::GM2Percussion::getThisIdentifier()) {}
+
+        babelwires::MapData getDefaultMapData() const override {
+            return getStandardDefaultMapData(babelwires::MapEntryData::Kind::AllToSame);
+        }
+    };
+} // namespace
+
+seqwires::PercussionMapProcessor::PercussionMapProcessor(const babelwires::ProjectContext& context)
+    : babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature>(context) {
+    m_percussionMapFeature = m_inputFeature->addField(
+        std::make_unique<PercussionTypeMap>(), REGISTERED_ID("Map", "Map", "b8cbf8c9-579b-4292-bdef-524b7d1010bc"));
+    addArrayFeature(REGISTERED_ID("Tracks", "Tracks", "fe71b1c6-6604-430b-a731-f40b2692d2cf"));
+}
+
+seqwires::PercussionMapProcessor::Factory::Factory()
+    : CommonProcessorFactory(
+          REGISTERED_LONGID("PercussionMapProcessor", "Percussion Map", "1ab6fd2b-8176-4516-9d9a-3b2d91a53f42"), 1) {}
+
+void seqwires::PercussionMapProcessor::processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input,
+                                               seqwires::TrackFeature& output) const {
+    const babelwires::ProjectContext& context = babelwires::RootFeature::getProjectContextAt(*m_percussionMapFeature);
+
+    output.set(std::make_unique<Track>(mapPercussionFunction(context.m_typeSystem, input.get(), m_percussionMapFeature->get())));
+}

--- a/SeqWiresLib/Processors/percussionMapProcessor.hpp
+++ b/SeqWiresLib/Processors/percussionMapProcessor.hpp
@@ -1,0 +1,31 @@
+/**
+ * Processor which maps percussion events.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <SeqWiresLib/Features/trackFeature.hpp>
+
+#include <BabelWiresLib/Processors/parallelProcessor.hpp>
+
+namespace babelwires { class MapFeature; }
+
+namespace seqwires {
+
+    class PercussionMapProcessor : public babelwires::ParallelProcessor<seqwires::TrackFeature, seqwires::TrackFeature> {
+      public:
+        PercussionMapProcessor(const babelwires::ProjectContext& context);
+
+        void processEntry(babelwires::UserLogger& userLogger, const seqwires::TrackFeature& input, seqwires::TrackFeature& output) const override;
+
+        struct Factory : public babelwires::CommonProcessorFactory<PercussionMapProcessor> {
+            Factory();
+        };
+
+      private:
+        babelwires::MapFeature* m_percussionMapFeature;
+    };
+} // namespace seqwires

--- a/SeqWiresLib/Tracks/noteEvents.hpp
+++ b/SeqWiresLib/Tracks/noteEvents.hpp
@@ -24,6 +24,12 @@ namespace seqwires {
 
         static GroupingInfo::Category s_noteEventCategory;
 
+        void setPitch(Pitch pitch) { m_pitch = pitch; }
+        Pitch getPitch() const { return m_pitch; }
+
+        void setVelocity(Velocity velocity) { m_velocity = velocity; }
+        Velocity getVelocity() const { return m_velocity; }
+
         Pitch m_pitch;
         Velocity m_velocity;
     };

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -25,13 +25,17 @@
 #include <SeqWiresLib/Processors/silenceProcessor.hpp>
 #include <SeqWiresLib/Processors/splitAtPitchProcessor.hpp>
 #include <SeqWiresLib/Processors/transposeProcessor.hpp>
+#include <SeqWiresLib/percussion.hpp>
 #include <SeqWiresLib/chord.hpp>
 #include <SeqWiresLib/pitchClass.hpp>
 
 void seqwires::registerLib(babelwires::ProjectContext& context) {
-    context.m_typeSystem.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
     context.m_typeSystem.addEntry(std::make_unique<ChordType>());
     context.m_typeSystem.addEntry(std::make_unique<PitchClass>());
+    context.m_typeSystem.addEntry(std::make_unique<GM2Percussion>());
+    context.m_typeSystem.addEntry(std::make_unique<GMPercussion>());
+
+    context.m_typeSystem.addEntry(std::make_unique<MonophonicSubtracksPolicyEnum>());
     context.m_typeSystem.addEntry(std::make_unique<FingeredChordsSustainPolicyEnum>());
 
     context.m_processorReg.addEntry(std::make_unique<ChordMapProcessor::Factory>());

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -21,6 +21,7 @@
 #include <SeqWiresLib/Processors/mergeProcessor.hpp>
 #include <SeqWiresLib/Processors/monophonicSubtracksProcessor.hpp>
 #include <SeqWiresLib/Processors/repeatProcessor.hpp>
+#include <SeqWiresLib/Processors/percussionMapProcessor.hpp>
 #include <SeqWiresLib/Processors/quantizeProcessor.hpp>
 #include <SeqWiresLib/Processors/silenceProcessor.hpp>
 #include <SeqWiresLib/Processors/splitAtPitchProcessor.hpp>
@@ -44,6 +45,7 @@ void seqwires::registerLib(babelwires::ProjectContext& context) {
     context.m_processorReg.addEntry(std::make_unique<MergeProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<MonophonicSubtracksProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<FingeredChordsProcessor::Factory>());
+    context.m_processorReg.addEntry(std::make_unique<PercussionMapProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<QuantizeProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<RepeatProcessor::Factory>());
     context.m_processorReg.addEntry(std::make_unique<SilenceProcessor::Factory>());

--- a/SeqWiresLib/percussion.cpp
+++ b/SeqWiresLib/percussion.cpp
@@ -1,0 +1,46 @@
+/**
+ * Defines enums for standard percussion sets.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <SeqWiresLib/percussion.hpp>
+
+#include <Common/Identifiers/identifierRegistry.hpp>
+
+ENUM_DEFINE_ENUM_VALUE_SOURCE(GM2_STANDARD_PERCUSSION_VALUES);
+
+babelwires::LongIdentifier seqwires::GM2Percussion::getThisIdentifier() {
+    return REGISTERED_LONGID("GM2Percussion", "General MIDI 2 Percussion", "9fc0c107-f76c-432a-af58-c794f01df455");
+}
+
+seqwires::GM2Percussion::GM2Percussion()
+    : Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(GM2_STANDARD_PERCUSSION_VALUES), 0) {}
+
+seqwires::Pitch seqwires::GM2Percussion::getPitchFromIndex(unsigned int index) {
+    return index + 35;
+}
+
+bool seqwires::GM2Percussion::tryGetIndexFromPitch(Pitch pitch, unsigned int& index) {
+    if ((pitch < 35) || (pitch > 81)) {
+        return false;
+    }
+    index = pitch - 35;
+    return true;
+}
+
+seqwires::GMPercussion::GMPercussion()
+    : babelwires::Enum(
+          getThisIdentifier(), 1,
+          babelwires::Enum::EnumValues{"AcBass", "Bass1",  "SStick", "AcSnr",  "Clap",   "ElSnr",  "LFlTom", "ClHHat",
+                                       "HFlTom", "PdHHat", "LwTom",  "OpHHat", "LMTom",  "HMTom",  "Crash1", "HTom",
+                                       "Ride1",  "ChnCym", "RideBl", "Tamb",   "SplCym", "Cowbl",  "Crash2", "VibraS",
+                                       "Ride2",  "HBongo", "LBongo", "MHCnga", "OHCnga", "LConga", "HTimbl", "LTimbl",
+                                       "HAgogo", "LAgogo", "Cabasa", "Maracs", "SWhisl", "LWhisl", "SGuiro", "LGuiro",
+                                       "Claves", "HWoodB", "LWoodB", "MCuica", "OCuica", "MTrian", "OTrian"},
+          1, seqwires::GM2Percussion::getThisIdentifier()) {}
+
+babelwires::LongIdentifier seqwires::GMPercussion::getThisIdentifier() {
+    return REGISTERED_LONGID("GMPercussion", "General MIDI Percussion", "9f6dec59-4d75-4a4b-9cba-e7ff76390c5f");
+}

--- a/SeqWiresLib/percussion.cpp
+++ b/SeqWiresLib/percussion.cpp
@@ -36,7 +36,7 @@ seqwires::GMPercussion::GMPercussion()
           getThisIdentifier(), 1,
           babelwires::Enum::EnumValues{"AcBass", "Bass1",  "SStick", "AcSnr",  "Clap",   "ElSnr",  "LFlTom", "ClHHat",
                                        "HFlTom", "PdHHat", "LwTom",  "OpHHat", "LMTom",  "HMTom",  "Crash1", "HTom",
-                                       "Ride1",  "ChnCym", "RideBl", "Tamb",   "SplCym", "Cowbl",  "Crash2", "VibraS",
+                                       "Ride1",  "ChnCym", "RideBl", "Tamb",   "SplCym", "Cowbll",  "Crash2", "VibraS",
                                        "Ride2",  "HBongo", "LBongo", "MHCnga", "OHCnga", "LConga", "HTimbl", "LTimbl",
                                        "HAgogo", "LAgogo", "Cabasa", "Maracs", "SWhisl", "LWhisl", "SGuiro", "LGuiro",
                                        "Claves", "HWoodB", "LWoodB", "MCuica", "OCuica", "MTrian", "OTrian"},

--- a/SeqWiresLib/percussion.cpp
+++ b/SeqWiresLib/percussion.cpp
@@ -18,7 +18,8 @@ babelwires::LongIdentifier seqwires::GM2Percussion::getThisIdentifier() {
 seqwires::GM2Percussion::GM2Percussion()
     : Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(GM2_STANDARD_PERCUSSION_VALUES), 0) {}
 
-seqwires::Pitch seqwires::GM2Percussion::getPitchFromIndex(unsigned int index) {
+seqwires::Pitch seqwires::GM2Percussion::getPitchFromValue(Value value) {
+    const unsigned int index = static_cast<unsigned int>(value);
     return index + 27;
 }
 

--- a/SeqWiresLib/percussion.cpp
+++ b/SeqWiresLib/percussion.cpp
@@ -19,14 +19,14 @@ seqwires::GM2Percussion::GM2Percussion()
     : Enum(getThisIdentifier(), 1, ENUM_IDENTIFIER_VECTOR(GM2_STANDARD_PERCUSSION_VALUES), 0) {}
 
 seqwires::Pitch seqwires::GM2Percussion::getPitchFromIndex(unsigned int index) {
-    return index + 35;
+    return index + 27;
 }
 
-bool seqwires::GM2Percussion::tryGetIndexFromPitch(Pitch pitch, unsigned int& index) {
-    if ((pitch < 35) || (pitch > 81)) {
+bool seqwires::GM2Percussion::tryGetValueFromPitch(Pitch pitch, Value& valueOut) const {
+    if ((pitch < 27) || (pitch > 87)) {
         return false;
     }
-    index = pitch - 35;
+    valueOut = static_cast<Value>(pitch - 27);
     return true;
 }
 

--- a/SeqWiresLib/percussion.hpp
+++ b/SeqWiresLib/percussion.hpp
@@ -89,8 +89,8 @@ namespace seqwires {
 
         ENUM_DEFINE_CPP_ENUM(GM2_STANDARD_PERCUSSION_VALUES);
 
-        /// Returns a pitch in the range 35..81.
-        static Pitch getPitchFromIndex(unsigned int index);
+        /// Returns a pitch in the range 27..87.
+        static Pitch getPitchFromValue(Value value);
 
         /// If the pitch is in range, set indexOut and return true.
         bool tryGetValueFromPitch(Pitch pitch, Value& indexOut) const;

--- a/SeqWiresLib/percussion.hpp
+++ b/SeqWiresLib/percussion.hpp
@@ -43,7 +43,7 @@
     X(RideBl, "Ride Bell", "b0fa8c86-df41-4e4b-b9ce-e04a935f1db4")                                                     \
     X(Tamb, "Tambourine", "1c7b945f-d6c8-4213-a6c2-e15667399f9f")                                                      \
     X(SplCym, "Splash Cymbal", "3a630d65-0fb0-4272-ac30-ede579203e6d")                                                 \
-    X(Cowbl, "Cowbell", "513e999a-40bf-4a3f-8164-c4b881300e4f")                                                        \
+    X(Cowbll, "Cowbell", "513e999a-40bf-4a3f-8164-c4b881300e4f")                                                        \
     X(Crash2, "Crash Cymbal 2", "b8604a23-c381-4cc5-aed4-fafa243a96f9")                                                \
     X(VibraS, "Vibraslap", "8948c9eb-31a1-4eb4-8b75-9b4a23c3b900")                                                     \
     X(Ride2, "Ride Cymbal 2", "266e41ce-c70c-4d51-8387-04025bf1b58d")                                                  \
@@ -78,9 +78,9 @@
     X(OSurdo, "Open Surdo", "16a9961e-26a2-4e85-bb8c-32b139713694")
 
 namespace seqwires {
-    // TODO GS, XG, GM2 percussion, with appropriate subtyping.
+    // TODO GS, XG percussion, with appropriate subtyping.
 
-    /// An enum corresponding to the instruments of GM percussion set.
+    /// An enum corresponding to the instruments of GM2 standard percussion set.
     class GM2Percussion : public babelwires::Enum {
       public:
         GM2Percussion();
@@ -96,6 +96,7 @@ namespace seqwires {
         bool tryGetValueFromPitch(Pitch pitch, Value& indexOut) const;
     };
 
+    /// An enum corresponding to the original General MIDI percussion set.
     struct GMPercussion : babelwires::Enum {
         GMPercussion();
 

--- a/SeqWiresLib/percussion.hpp
+++ b/SeqWiresLib/percussion.hpp
@@ -1,0 +1,104 @@
+/**
+ * Defines enums for standard percussion sets.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <SeqWiresLib/musicTypes.hpp>
+
+#include <BabelWiresLib/Enums/enumWithCppEnum.hpp>
+
+#define GM2_STANDARD_PERCUSSION_VALUES(X)                                                                              \
+    /* GM2 Standard Set */                                                                                             \
+    X(HighQ, "High Q", "22074fd9-40ed-4716-8e5b-4e174daa03b3")                                                         \
+    X(Slap, "Slap", "3aedf5de-904b-46e2-bc87-445c9f065868")                                                            \
+    X(ScrPsh, "Scratch Push", "3087699b-94bd-4612-b1bd-b5acf037c325")                                                  \
+    X(ScrPll, "Scratch Pull", "8a74f73e-691d-445f-bd2e-fd75bc91a8ef")                                                  \
+    X(Stcks, "Sticks", "c61880f7-2ed2-431b-b23a-14a5457bacfd")                                                         \
+    X(SqClck, "Square Click", "4d887ce2-c748-4127-b3ed-f8430237a82f")                                                  \
+    X(MtrClk, "Metronome Click", "a012ad55-b894-4687-8754-6574f492f90e")                                               \
+    X(MtrBll, "Metronome Bell", "876abe67-81a4-41dd-9d7b-dbc3652c47a1")                                                \
+    /* GM Percussion Set - common to GM2, GS and XG sets */                                                            \
+    X(AcBass, "Acoustic Bass Drum", "6ce9c1ac-3439-41eb-9776-dac41184255c")                                            \
+    X(Bass1, "Bass Drum 1", "1c39fd51-ed6b-439e-ac8e-3c0fc7cb0d3b")                                                    \
+    X(SStick, "Side Stick", "7762bf9b-ee64-4af2-9397-f6a55751f845")                                                    \
+    X(AcSnr, "Acoustic Snare", "86d0c201-7866-4d81-bf54-2417ff8d94b6")                                                 \
+    X(Clap, "Hand Clap", "377aa8da-201c-4279-8db0-8bb1bfff48b3")                                                       \
+    X(ElSnr, "Electric Snare", "d89ecda6-b911-47d3-b4a1-5bf24e358a52")                                                 \
+    X(LFlTom, "Low Floor Tom", "1c125e5d-8764-4704-919b-a00a505d48bf")                                                 \
+    X(ClHHat, "Closed Hi Hat", "594b33b1-61e6-44ee-877b-e12ff7309bf3")                                                 \
+    X(HFlTom, "High Floor Tom", "df566de2-2e0d-4417-9ad0-a0225a28be81")                                                \
+    X(PdHHat, "Pedal Hi Hat", "e79e3113-34da-4faa-ad71-fe6200c23a4b")                                                  \
+    X(LwTom, "Low Tom", "4e0844b0-b79b-40ef-ae6d-8fbb8476799c")                                                        \
+    X(OpHHat, "Open Hi Hat", "0fba2ee3-8223-4275-b4ac-06186824571d")                                                   \
+    X(LMTom, "Low-Mid Tom", "8daf9af5-5839-4a60-a0fa-9ce7f8ddce23")                                                    \
+    X(HMTom, "Hi-Mid Tom", "d05899d0-bee6-42ab-ae27-288bd7d35894")                                                     \
+    X(Crash1, "Crash Cymbal 1", "19b94421-a2db-481c-a5c6-d760884e8b3f")                                                \
+    X(HTom, "High Tom", "9a125d11-0376-4ae5-a4b0-8870fae943f6")                                                        \
+    X(Ride1, "Ride Cymbal 1", "325540cc-bce6-4f4f-babd-89b56a48002d")                                                  \
+    X(ChnCym, "Chinese Cymbal", "963bc408-32e7-4c33-a743-764ed26423d8")                                                \
+    X(RideBl, "Ride Bell", "b0fa8c86-df41-4e4b-b9ce-e04a935f1db4")                                                     \
+    X(Tamb, "Tambourine", "1c7b945f-d6c8-4213-a6c2-e15667399f9f")                                                      \
+    X(SplCym, "Splash Cymbal", "3a630d65-0fb0-4272-ac30-ede579203e6d")                                                 \
+    X(Cowbl, "Cowbell", "513e999a-40bf-4a3f-8164-c4b881300e4f")                                                        \
+    X(Crash2, "Crash Cymbal 2", "b8604a23-c381-4cc5-aed4-fafa243a96f9")                                                \
+    X(VibraS, "Vibraslap", "8948c9eb-31a1-4eb4-8b75-9b4a23c3b900")                                                     \
+    X(Ride2, "Ride Cymbal 2", "266e41ce-c70c-4d51-8387-04025bf1b58d")                                                  \
+    X(HBongo, "Hi Bongo", "a04a6551-b076-4bcc-a909-51ee8547e46c")                                                      \
+    X(LBongo, "Low Bongo", "023c2b30-5616-42ce-93ca-0051b26487ba")                                                     \
+    X(MHCnga, "Mute Hi Conga", "baaf8149-a3a4-479a-916f-cc34e8eaffc7")                                                 \
+    X(OHCnga, "Open Hi Conga", "7188bb81-1e73-4c66-91c0-c9af3a8dcd38")                                                 \
+    X(LConga, "Low Conga", "9c9eba72-632f-4a46-8c43-46425c0f8918")                                                     \
+    X(HTimbl, "High Timbale", "da75f840-55a7-41c9-b74b-69c3ee16a299")                                                  \
+    X(LTimbl, "Low Timbale", "fa81b07d-7c14-4331-8390-046166dc869f")                                                   \
+    X(HAgogo, "High Agogo", "5b6f72e1-c491-42b4-b8b8-1e49648190fd")                                                    \
+    X(LAgogo, "Low Agogo", "5709ee1f-50a0-44a2-a4e2-be2cf0b0affb")                                                     \
+    X(Cabasa, "Cabasa", "feb12af2-bcaa-42cc-8325-ac5f73fdd835")                                                        \
+    X(Maracs, "Maracas", "d824a9de-1c48-460d-b186-cdbe92329eaa")                                                       \
+    X(SWhisl, "Short Whistle", "122a08b8-37cb-4caa-a12c-5ae4888475ac")                                                 \
+    X(LWhisl, "Long Whistle", "f47406bb-47a1-47a1-b526-004ed56e0a16")                                                  \
+    X(SGuiro, "Short Guiro", "cb801da6-8aad-4e29-bfed-83ed25490ff4")                                                   \
+    X(LGuiro, "Long Guiro", "3bbd1626-0258-41d1-a84c-8c59939e3313")                                                    \
+    X(Claves, "Claves", "76262dc4-7b66-4d8e-a68a-2ee29f675562")                                                        \
+    X(HWoodB, "Hi Wood Block", "568178ca-43a8-454e-8415-02bceb1ecb36")                                                 \
+    X(LWoodB, "Low Wood Block", "9e8ff317-af8c-4f99-a6d0-41a38ca6da96")                                                \
+    X(MCuica, "Mute Cuica", "419d9a21-3b53-45f5-bf5a-fcdc72837708")                                                    \
+    X(OCuica, "Open Cuica", "2e523d69-fea3-4145-96b7-1402f61472d5")                                                    \
+    X(MTrian, "Mute Triangle", "8d72a586-72ee-48fe-9bbd-c1a3500ab648")                                                 \
+    X(OTrian, "Open Triangle", "8ffa30b4-287f-4dcf-8d18-92def658e0d6")                                                 \
+    /* GM2 Standard Set */                                                                                             \
+    X(Shaker, "Shaker", "ee9c029a-98af-4679-adc4-3c5185ca2e95")                                                        \
+    X(JngBll, "Jingle Bell", "4a3da07d-a820-44f0-98fc-8c409768f7c2")                                                   \
+    X(BlTree, "Bell Tree", "770dd65c-6dd1-43ba-89f8-c4507c158709")                                                     \
+    X(Cstnts, "Castanets", "f742bbe3-3679-4cbd-9727-5252fd1bfff1")                                                     \
+    X(MSurdo, "Mute Surdo", "79286a74-fd6d-4918-8f4c-f79606e48d4e")                                                    \
+    X(OSurdo, "Open Surdo", "16a9961e-26a2-4e85-bb8c-32b139713694")
+
+namespace seqwires {
+    // TODO GS, XG, GM2 percussion, with appropriate subtyping.
+
+    /// An enum corresponding to the instruments of GM percussion set.
+    class GM2Percussion : public babelwires::Enum {
+      public:
+        GM2Percussion();
+
+        static babelwires::LongIdentifier getThisIdentifier();
+
+        ENUM_DEFINE_CPP_ENUM(GM2_STANDARD_PERCUSSION_VALUES);
+
+        /// Returns a pitch in the range 35..81.
+        static Pitch getPitchFromIndex(unsigned int index);
+
+        /// If the pitch is in range, set indexOut and return true.
+        bool tryGetIndexFromPitch(Pitch pitch, unsigned int& indexOut);
+    };
+
+    struct GMPercussion : babelwires::Enum {
+        GMPercussion();
+
+        static babelwires::LongIdentifier getThisIdentifier();
+    };
+} // namespace seqwires

--- a/SeqWiresLib/percussion.hpp
+++ b/SeqWiresLib/percussion.hpp
@@ -93,7 +93,7 @@ namespace seqwires {
         static Pitch getPitchFromIndex(unsigned int index);
 
         /// If the pitch is in range, set indexOut and return true.
-        bool tryGetIndexFromPitch(Pitch pitch, unsigned int& indexOut);
+        bool tryGetValueFromPitch(Pitch pitch, Value& indexOut) const;
     };
 
     struct GMPercussion : babelwires::Enum {

--- a/Tests/SeqWiresLib/CMakeLists.txt
+++ b/Tests/SeqWiresLib/CMakeLists.txt
@@ -9,6 +9,7 @@ SET( SEQUENCELIB_TESTS_SRCS
       monophonicNoteIteratorTest.cpp
       monophonicSubtracksProcessorTest.cpp
       musicTypesTest.cpp
+      percussionMapProcessorTest.cpp
       quantizeProcessorTest.cpp
       repeatProcessorTest.cpp
       sanitizingFunctionsTest.cpp

--- a/Tests/SeqWiresLib/percussionMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/percussionMapProcessorTest.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <SeqWiresLib/Functions/percussionMapFunction.hpp>
+#include <SeqWiresLib/Processors/percussionMapProcessor.hpp>
+#include <SeqWiresLib/Tracks/track.hpp>
+#include <SeqWiresLib/percussion.hpp>
+
+#include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Maps/MapEntries/allToSameFallbackMapEntryData.hpp>
+#include <BabelWiresLib/Maps/MapEntries/oneToOneMapEntryData.hpp>
+#include <BabelWiresLib/Maps/mapData.hpp>
+#include <BabelWiresLib/TypeSystem/enumValue.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+
+#include <Tests/BabelWiresLib/TestUtils/testEnvironment.hpp>
+#include <Tests/TestUtils/seqTestUtils.hpp>
+#include <Tests/TestUtils/testLog.hpp>
+
+namespace {
+    babelwires::MapData getTestPercussionMap(const babelwires::TypeSystem& typeSystem) {
+        const seqwires::GM2Percussion& percussionType =
+            typeSystem.getRegisteredEntry(seqwires::GM2Percussion::getThisIdentifier()).is<seqwires::GM2Percussion>();
+
+        babelwires::MapData percussionMap;
+        percussionMap.setSourceTypeId(seqwires::GMPercussion::getThisIdentifier());
+        percussionMap.setTargetTypeId(seqwires::GMPercussion::getThisIdentifier());
+
+        babelwires::OneToOneMapEntryData maplet(typeSystem, seqwires::GM2Percussion::getThisIdentifier(),
+                                                seqwires::GM2Percussion::getThisIdentifier());
+
+        babelwires::EnumValue sourceValue;
+        babelwires::EnumValue targetValue;
+
+        sourceValue.set(percussionType.getIdentifierFromValue(seqwires::GM2Percussion::Value::Clap));
+        targetValue.set(percussionType.getIdentifierFromValue(seqwires::GM2Percussion::Value::Cowbll));
+        maplet.setSourceValue(sourceValue.clone());
+        maplet.setTargetValue(targetValue.clone());
+        percussionMap.emplaceBack(maplet.clone());
+
+        sourceValue.set(percussionType.getIdentifierFromValue(seqwires::GM2Percussion::Value::Crash1));
+        targetValue.set(percussionType.getIdentifierFromValue(seqwires::GM2Percussion::Value::Crash2));
+        maplet.setSourceValue(sourceValue.clone());
+        maplet.setTargetValue(targetValue.clone());
+        percussionMap.emplaceBack(maplet.clone());
+
+        percussionMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
+        return percussionMap;
+    }
+} // namespace
+
+TEST(PercussionMapProcessorTest, funcSimple) {
+    testUtils::TestLog log;
+
+    babelwires::TypeSystem typeSystem;
+    typeSystem.addEntry(std::make_unique<seqwires::GM2Percussion>());
+    typeSystem.addEntry(std::make_unique<seqwires::GMPercussion>());
+
+    babelwires::MapData mapData = getTestPercussionMap(typeSystem);
+
+    seqwires::Track inputTrack;
+
+    testUtils::addNotes(
+        {
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
+             babelwires::Rational(1, 2)},
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Clap), 0,
+             babelwires::Rational(1, 2)},
+            {12, 0, babelwires::Rational(1, 2)},
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash1), 0,
+             babelwires::Rational(1, 2)},
+        },
+        inputTrack);
+
+    seqwires::Track outputTrack = seqwires::mapPercussionFunction(typeSystem, inputTrack, mapData);
+
+    EXPECT_EQ(inputTrack.getDuration(), outputTrack.getDuration());
+
+    testUtils::testNotes(
+        {
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
+             babelwires::Rational(1, 2)},
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Cowbll), 0,
+             babelwires::Rational(1, 2)},
+            // The out of range note gets dropped here.
+            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash2),
+             babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
+        },
+        outputTrack);
+}

--- a/Tests/SeqWiresLib/percussionMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/percussionMapProcessorTest.cpp
@@ -46,6 +46,38 @@ namespace {
         percussionMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
         return percussionMap;
     }
+
+    seqwires::Track getTestInputTrack() {
+        seqwires::Track track;
+
+        testUtils::addNotes(
+            {
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
+                 babelwires::Rational(1, 2)},
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Clap), 0,
+                 babelwires::Rational(1, 2)},
+                {12, 0, babelwires::Rational(1, 2)},
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash1), 0,
+                 babelwires::Rational(1, 2)},
+            },
+            track);
+
+        return track;
+    }
+
+    void testOutputTrack(const seqwires::Track& outputTrack) {
+        testUtils::testNotes(
+            {
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
+                 babelwires::Rational(1, 2)},
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Cowbll), 0,
+                 babelwires::Rational(1, 2)},
+                // The out of range note gets dropped here.
+                {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash2),
+                 babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
+            },
+            outputTrack);
+    }
 } // namespace
 
 TEST(PercussionMapProcessorTest, funcSimple) {
@@ -57,33 +89,53 @@ TEST(PercussionMapProcessorTest, funcSimple) {
 
     babelwires::MapData mapData = getTestPercussionMap(typeSystem);
 
-    seqwires::Track inputTrack;
-
-    testUtils::addNotes(
-        {
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
-             babelwires::Rational(1, 2)},
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Clap), 0,
-             babelwires::Rational(1, 2)},
-            {12, 0, babelwires::Rational(1, 2)},
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash1), 0,
-             babelwires::Rational(1, 2)},
-        },
-        inputTrack);
+    seqwires::Track inputTrack = getTestInputTrack();
 
     seqwires::Track outputTrack = seqwires::mapPercussionFunction(typeSystem, inputTrack, mapData);
 
+    testOutputTrack(outputTrack);
     EXPECT_EQ(inputTrack.getDuration(), outputTrack.getDuration());
+}
 
-    testUtils::testNotes(
-        {
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::AcBass), 0,
-             babelwires::Rational(1, 2)},
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Cowbll), 0,
-             babelwires::Rational(1, 2)},
-            // The out of range note gets dropped here.
-            {seqwires::GM2Percussion::getPitchFromValue(seqwires::GM2Percussion::Value::Crash2),
-             babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-        },
-        outputTrack);
+TEST(PercussionMapProcessorTest, processor) {
+    testUtils::TestEnvironment testEnvironment;
+    testEnvironment.m_typeSystem.addEntry(std::make_unique<seqwires::GM2Percussion>());
+    testEnvironment.m_typeSystem.addEntry(std::make_unique<seqwires::GMPercussion>());
+
+    const seqwires::GM2Percussion& percussionType =
+        testEnvironment.m_typeSystem.getRegisteredEntry(seqwires::GM2Percussion::getThisIdentifier())
+            .is<seqwires::GM2Percussion>();
+
+    seqwires::PercussionMapProcessor processor(testEnvironment.m_projectContext);
+
+    processor.getInputFeature()->setToDefault();
+    processor.getOutputFeature()->setToDefault();
+
+    auto* percussionMapFeature =
+        processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Map")).as<babelwires::MapFeature>();
+    auto* inputArray =
+        processor.getInputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    auto* outputArray =
+        processor.getOutputFeature()->getChildFromStep(babelwires::PathStep("Tracks")).as<babelwires::ArrayFeature>();
+    ASSERT_NE(percussionMapFeature, nullptr);
+    ASSERT_NE(inputArray, nullptr);
+    ASSERT_NE(outputArray, nullptr);
+
+    EXPECT_EQ(inputArray->getNumFeatures(), 1);
+    EXPECT_EQ(outputArray->getNumFeatures(), 1);
+
+    auto getInputTrack = [&inputArray](int i) { return inputArray->getChildFromStep(i).as<seqwires::TrackFeature>(); };
+    auto getOutputTrack = [&outputArray](int i) {
+        return outputArray->getChildFromStep(i).as<seqwires::TrackFeature>();
+    };
+
+    ASSERT_NE(getInputTrack(0), nullptr);
+    ASSERT_NE(getOutputTrack(0), nullptr);
+
+    percussionMapFeature->set(getTestPercussionMap(testEnvironment.m_typeSystem));
+    getInputTrack(0)->set(getTestInputTrack());
+
+    processor.process(testEnvironment.m_log);
+
+    testOutputTrack(getOutputTrack(0)->get());
 }


### PR DESCRIPTION
Just a basic implementation for now, with support for the GM and GM2 standard set.

Will add GS, XG and other sets from GM2 in subsequent change. However, I will need to adjust the type system to support types with more than one supertype (since ideally, GM would be a subtype of all of those sets).

Also missing is the ability to drop the events of percussion instruments. Again, this requires adjustments to the underlying type system / enums.