### PR TITLE
ChordMapProcessor now using Tuples

### DIFF
--- a/SeqWiresLib/Functions/mapChordsFunction.cpp
+++ b/SeqWiresLib/Functions/mapChordsFunction.cpp
@@ -233,7 +233,7 @@ seqwires::Track seqwires::mapChordsFunction(const babelwires::TypeSystem& typeSy
     Track trackOut;
     ModelDuration totalEventDuration;
 
-    std::optional<seqwires::Chord> noChordChord = mapApplicator.getNoChordTarget();
+    std::optional<seqwires::Chord> silenceToChordChord = mapApplicator.getNoChordTarget();
 
     enum {
         pending,
@@ -249,8 +249,8 @@ seqwires::Track seqwires::mapChordsFunction(const babelwires::TypeSystem& typeSy
         timeSinceLastEvent += it->getTimeSinceLastEvent();
         totalEventDuration += it->getTimeSinceLastEvent();
 
-        if (noChordChord && (state == pending) && (timeSinceLastEvent > 0)) {
-            trackOut.addEvent(ChordOnEvent(0, *noChordChord));
+        if (silenceToChordChord && (state == pending) && (timeSinceLastEvent > 0)) {
+            trackOut.addEvent(ChordOnEvent(0, *silenceToChordChord));
             state = silenceToChord;
         }
 
@@ -289,8 +289,8 @@ seqwires::Track seqwires::mapChordsFunction(const babelwires::TypeSystem& typeSy
         }
     }
     timeSinceLastEvent += sourceTrack.getDuration() - totalEventDuration;
-    if (noChordChord && (state == pending) && (timeSinceLastEvent > 0)) {
-        trackOut.addEvent(ChordOnEvent(0, *noChordChord));
+    if (silenceToChordChord && (state == pending) && (timeSinceLastEvent > 0)) {
+        trackOut.addEvent(ChordOnEvent(0, *silenceToChordChord));
         state = silenceToChord;
     }
     if (state == silenceToChord) {

--- a/SeqWiresLib/Functions/mapChordsFunction.cpp
+++ b/SeqWiresLib/Functions/mapChordsFunction.cpp
@@ -147,9 +147,9 @@ namespace {
                     if (const babelwires::TupleValue* sourceTuple =
                             entry.getSourceValue()->as<babelwires::TupleValue>()) {
                         const unsigned int pitchClassIndex =
-                            m_targetPitchClassAdapter(sourceTuple->getValue(0)->is<babelwires::EnumValue>());
+                            m_sourcePitchClassAdapter(sourceTuple->getValue(0)->is<babelwires::EnumValue>());
                         const unsigned int chordTypeIndex =
-                            m_targetChordTypeAdapter(sourceTuple->getValue(1)->is<babelwires::EnumValue>());
+                            m_sourceChordTypeAdapter(sourceTuple->getValue(1)->is<babelwires::EnumValue>());
                         if (((static_cast<unsigned int>(chord.m_root) + 1 == pitchClassIndex) ||
                              (pitchClassIndex == 0)) &&
                             ((static_cast<unsigned int>(chord.m_chordType) + 1 == chordTypeIndex) ||

--- a/SeqWiresLib/Functions/mapChordsFunction.hpp
+++ b/SeqWiresLib/Functions/mapChordsFunction.hpp
@@ -13,12 +13,11 @@ namespace babelwires {
 }
 
 namespace seqwires {
-    babelwires::TypeRef getMapChordFunctionChordTypeRef();
-    babelwires::TypeRef getMapChordFunctionPitchClassRef();
+    babelwires::TypeRef getMapChordFunctionSourceTypeRef();
+    babelwires::TypeRef getMapChordFunctionTargetTypeRef();
 
     /// Apply maps to chord events in the track.
     /// You can specify a chord that should be active when no chord in the sourceTrack is active
     /// by having blanks in the source map.
-    /// Until the type system has cross products, this will be somewhat limited in value.
-    Track mapChordsFunction(const babelwires::TypeSystem& typeSystem, const Track& sourceTrack, const babelwires::MapValue& chordTypeMapValue, const babelwires::MapValue& pitchClassMapValue);
+    Track mapChordsFunction(const babelwires::TypeSystem& typeSystem, const Track& sourceTrack, const babelwires::MapValue& chordMapValue);
 }

--- a/SeqWiresLib/Functions/percussionMapFunction.cpp
+++ b/SeqWiresLib/Functions/percussionMapFunction.cpp
@@ -15,7 +15,6 @@
 #include <BabelWiresLib/ValueTree/modelExceptions.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 #include <BabelWiresLib/Types/Enum/addBlankToEnum.hpp>
-#include <BabelWiresLib/Types/Map/Helpers/enumSourceMapApplicator.hpp>
 #include <BabelWiresLib/Types/Map/Helpers/enumValueAdapters.hpp>
 #include <BabelWiresLib/Types/Map/Helpers/unorderedMapApplicator.hpp>
 #include <BabelWiresLib/Types/Map/mapTypeConstructor.hpp>

--- a/SeqWiresLib/Processors/chordMapProcessor.cpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.cpp
@@ -19,14 +19,10 @@
 
 seqwires::ChordMapProcessorInput::ChordMapProcessorInput()
     : babelwires::ParallelProcessorInputBase(
-          {{BW_SHORT_ID("TypMap", "Type map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"),
-            babelwires::MapTypeConstructor::makeTypeRef(seqwires::getMapChordFunctionChordTypeRef(),
-                                                        seqwires::getMapChordFunctionChordTypeRef(),
-                                                        babelwires::MapEntryData::Kind::All2Sm)},
-           {BW_SHORT_ID("RtMap", "Root map", "4df92989-554b-426a-aa0c-2c0c7ca2dfd6"),
-            babelwires::MapTypeConstructor::makeTypeRef(seqwires::getMapChordFunctionPitchClassRef(),
-                                                        seqwires::getMapChordFunctionPitchClassRef(),
-                                                        babelwires::MapEntryData::Kind::All2Sm)}},
+          {{BW_SHORT_ID("ChrdMp", "Chord map", "6054b8e9-5f48-4e9f-8807-b6377d36d6aa"),
+            babelwires::MapTypeConstructor::makeTypeRef(seqwires::getMapChordFunctionSourceTypeRef(),
+                                                        seqwires::getMapChordFunctionTargetTypeRef(),
+                                                        babelwires::MapEntryData::Kind::All21)}},
           ChordMapProcessor::getCommonArrayId(), seqwires::DefaultTrackType::getThisType()) {}
 
 seqwires::ChordMapProcessorOutput::ChordMapProcessorOutput()
@@ -49,8 +45,7 @@ void seqwires::ChordMapProcessor::processEntry(babelwires::UserLogger& userLogge
     babelwires::ConstInstance<TrackType> entryIn{inputEntry};
     babelwires::Instance<TrackType> entryOut{outputEntry};
 
-    const auto& chordTypeMap = in.getTypMap()->getValue()->is<babelwires::MapValue>();
-    const auto& chordRootMap = in.getRtMap()->getValue()->is<babelwires::MapValue>();
+    const auto& chordMap = in.getChrdMp()->getValue()->is<babelwires::MapValue>();
 
-    entryOut.set(mapChordsFunction(in->getTypeSystem(), entryIn.get(), chordTypeMap, chordRootMap));
+    entryOut.set(mapChordsFunction(in->getTypeSystem(), entryIn.get(), chordMap));
 }

--- a/SeqWiresLib/Processors/chordMapProcessor.hpp
+++ b/SeqWiresLib/Processors/chordMapProcessor.hpp
@@ -23,8 +23,7 @@ namespace seqwires {
         ChordMapProcessorInput();
 
         DECLARE_INSTANCE_BEGIN(ChordMapProcessorInput)
-        DECLARE_INSTANCE_MAP_FIELD(TypMap, babelwires::EnumType, babelwires::EnumType)
-        DECLARE_INSTANCE_MAP_FIELD(RtMap, babelwires::EnumType, babelwires::EnumType)
+        DECLARE_INSTANCE_MAP_FIELD(ChrdMp, babelwires::EnumType, babelwires::EnumType)
         DECLARE_INSTANCE_END()
     };
 

--- a/SeqWiresLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/SeqWiresLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -49,6 +49,7 @@ namespace seqwires {
         /// all of the same pitch.
         struct GroupingInfo {
             /// A static string can act as a category.
+            // TODO Use an identifier for this.
             using Category = const char*;
 
             /// A category that can be used for events of no particular category.

--- a/SeqWiresLib/chord.cpp
+++ b/SeqWiresLib/chord.cpp
@@ -13,3 +13,10 @@ ENUM_DEFINE_ENUM_VALUE_SOURCE(seqwires::ChordType, CHORD_TYPE_VALUES);
 
 seqwires::ChordType::ChordType()
     : EnumType(getStaticValueSet(), 0) {}
+
+seqwires::NoChord::NoChord()
+    : EnumType({getNoChordValue()}, 0) {}
+
+babelwires::ShortId seqwires::NoChord::getNoChordValue() {
+    return BW_SHORT_ID("NoChrd","No Chord", "026e8e78-bb05-4386-8a67-2034890acd6e");
+}

--- a/SeqWiresLib/chord.hpp
+++ b/SeqWiresLib/chord.hpp
@@ -85,4 +85,14 @@ namespace seqwires {
         bool operator!=(Chord other) const { return (m_root != other.m_root) || (m_chordType != other.m_chordType); }
     };
 
+    /// A type with a single value meaning "NoChord".
+    class NoChord : public babelwires::EnumType {
+      public:
+        PRIMITIVE_TYPE("NoChord", "No Chord", "5f51a358-0121-4d1d-a0ab-cce5bddf92f1", 1);
+
+        NoChord();
+
+        static babelwires::ShortId getNoChordValue();
+    };
+
 } // namespace seqwires

--- a/SeqWiresLib/libRegistration.cpp
+++ b/SeqWiresLib/libRegistration.cpp
@@ -37,6 +37,7 @@
 void seqwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<DefaultTrackType>();
     context.m_typeSystem.addEntry<ChordType>();
+    context.m_typeSystem.addEntry<NoChord>();
     context.m_typeSystem.addEntry<PitchClass>();
     context.m_typeSystem.addEntry<PitchEnum>();
     context.m_typeSystem.addEntry<BuiltInPercussionInstruments>();

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@ SeqWires:
 * Improved handling of event truncation: 
   - Use new group events to denote truncated end and start. 
   - When truncated end meets truncated start, act as though event was not truncated.
+* TrackEvent::Category should be an identifier.
 
 Seq2tape:
 * Add support for setting name and copyright from commandline.
@@ -23,4 +24,6 @@ SMF
 Processors:
 * Harmonize - Attempted to adapt notes to a given chord (This is supported by arranger keyboards)
 * First note, last note - Can be combined with the excerpt processor (and possibly quantize) to trim a track.
-* etc.
+* Split by event category - Build a record of tracks by category
+  - Would need category to be an identifier (see above)
+  - Record type constructors (See BabelWires PR) OR registry of categories.

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -40,20 +40,12 @@ namespace {
             babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
                                                          seqwires::getMapChordFunctionTargetTypeRef());
 
-            babelwires::EnumValue pitchClassSourceValue;
-            pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
-
-            babelwires::EnumValue chordTypeSourceValue;
-            chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
-
+            babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
+            babelwires::EnumValue chordTypeSourceValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
             babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
-            babelwires::EnumValue pitchClassTargetValue;
-            pitchClassTargetValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
-
-            babelwires::EnumValue chordTypeTargetValue;
-            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
-
+            babelwires::EnumValue pitchClassTargetValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
+            babelwires::EnumValue chordTypeTargetValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
             babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
             chordMaplet.setSourceValue(sourceValue);
@@ -65,15 +57,10 @@ namespace {
             babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
                                                          seqwires::getMapChordFunctionTargetTypeRef());
 
-            babelwires::EnumValue sourceValue;
-            sourceValue.set(seqwires::NoChord::getNoChordValue());
+            babelwires::EnumValue sourceValue(seqwires::NoChord::getNoChordValue());
 
-            babelwires::EnumValue pitchClassTargetValue;
-            pitchClassTargetValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
-
-            babelwires::EnumValue chordTypeTargetValue;
-            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
-
+            babelwires::EnumValue pitchClassTargetValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
+            babelwires::EnumValue chordTypeTargetValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
             babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
             chordMaplet.setSourceValue(sourceValue);
@@ -86,12 +73,8 @@ namespace {
                 babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
                                                              seqwires::getMapChordFunctionTargetTypeRef());
 
-                babelwires::EnumValue pitchClassSourceValue;
-                pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Gsh));
-
-                babelwires::EnumValue chordTypeSourceValue;
-                chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
-
+                babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Gsh));
+                babelwires::EnumValue chordTypeSourceValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
                 babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
                 babelwires::EnumValue targetValue;
@@ -106,11 +89,8 @@ namespace {
                 babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
                                                              seqwires::getMapChordFunctionTargetTypeRef());
 
-                babelwires::EnumValue pitchClassSourceValue;
-                pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Dsh));
-
+                babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Dsh));
                 babelwires::EnumValue wildcardValue(babelwires::getWildcardId());
-
                 babelwires::TupleValue sourceValue({pitchClassSourceValue, wildcardValue});
 
                 babelwires::EnumValue targetValue;
@@ -126,9 +106,7 @@ namespace {
             babelwires::AllToOneFallbackMapEntryData chordMaplet(typeSystem,
                                                                  seqwires::getMapChordFunctionTargetTypeRef());
 
-            babelwires::EnumValue wildcardValue;
-            wildcardValue.set(babelwires::getWildcardMatchId());
-
+            babelwires::EnumValue wildcardValue(babelwires::getWildcardMatchId());
             babelwires::TupleValue targetValue({wildcardValue, wildcardValue});
 
             chordMaplet.setTargetValue(targetValue);

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -63,11 +63,10 @@ namespace {
                     chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M7s11));
                 babelwires::TupleValue sourceValue({wildcardValue, chordTypeSourceValue});
 
-                babelwires::EnumValue pitchClassTargetValue(
-                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::B));
+                babelwires::EnumValue wildcardMatchValue(babelwires::getWildcardMatchId());
                 babelwires::EnumValue chordTypeTargetValue(
                     chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
-                babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+                babelwires::TupleValue targetValue({wildcardMatchValue, chordTypeTargetValue});
 
                 chordMaplet.setSourceValue(sourceValue);
                 chordMaplet.setTargetValue(targetValue);
@@ -75,19 +74,17 @@ namespace {
             }
         }
         if (sourceMode == SourceMode::SilenceToChord) {
-            {
-                babelwires::EnumValue sourceValue(seqwires::NoChord::getNoChordValue());
+            babelwires::EnumValue sourceValue(seqwires::NoChord::getNoChordValue());
 
-                babelwires::EnumValue pitchClassTargetValue(
-                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
-                babelwires::EnumValue chordTypeTargetValue(
-                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
-                babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+            babelwires::EnumValue pitchClassTargetValue(
+                pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
+            babelwires::EnumValue chordTypeTargetValue(
+                chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
+            babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
-                chordMaplet.setSourceValue(sourceValue);
-                chordMaplet.setTargetValue(targetValue);
-                chordMap.emplaceBack(chordMaplet.clone());
-            }
+            chordMaplet.setSourceValue(sourceValue);
+            chordMaplet.setTargetValue(targetValue);
+            chordMap.emplaceBack(chordMaplet.clone());
         }
         if (targetMode == TargetMode::ChordToSilence) {
             {
@@ -144,7 +141,7 @@ namespace {
                               {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                               {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m},
-                              {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
+                              {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::M7s11}},
                              track);
 
         track.setDuration(babelwires::Rational(11, 2));
@@ -167,7 +164,7 @@ namespace {
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                        {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                                       {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
+                                       {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::M7s11}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::ChordToChord) && (targetMode == TargetMode::ChordToSilence)) {
                 testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
@@ -179,7 +176,7 @@ namespace {
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                        {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                                       {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
+                                       {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::M7s11}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToChord)) {
                 testUtils::testChords(
@@ -192,7 +189,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11},
+                     {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::M7s11},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToSilence)) {
@@ -206,7 +203,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11},
+                     {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::M7s11},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             }
@@ -221,7 +218,7 @@ namespace {
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                        {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                                       {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::m7}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::ChordToChord) && (targetMode == TargetMode::ChordToSilence)) {
                 testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
@@ -232,7 +229,7 @@ namespace {
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                        {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                                       {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::m7}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToChord)) {
                 testUtils::testChords(
@@ -245,7 +242,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                     {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::m7},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToSilence)) {
@@ -258,7 +255,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                     {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::Csh, seqwires::ChordType::ChordType::Value::m7},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      },
                     outputTrack);

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -9,133 +9,109 @@
 #include <SeqWiresLib/libRegistration.hpp>
 
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
-#include <BabelWiresLib/Types/Enum/addBlankToEnum.hpp>
 #include <BabelWiresLib/Types/Enum/enumValue.hpp>
-#include <BabelWiresLib/Types/Map/MapEntries/allToSameFallbackMapEntryData.hpp>
+#include <BabelWiresLib/Types/Map/MapEntries/allToOneFallbackMapEntryData.hpp>
 #include <BabelWiresLib/Types/Map/MapEntries/oneToOneMapEntryData.hpp>
 #include <BabelWiresLib/Types/Map/mapValue.hpp>
+#include <BabelWiresLib/Types/Map/standardMapIdentifiers.hpp>
+#include <BabelWiresLib/Types/Tuple/tupleValue.hpp>
 #include <BabelWiresLib/ValueTree/valueTreeRoot.hpp>
 
 #include <Tests/BabelWiresLib/TestUtils/testEnvironment.hpp>
 #include <Tests/TestUtils/seqTestUtils.hpp>
 #include <Tests/TestUtils/testLog.hpp>
 
-/*
 namespace {
     enum class Mode { NoBlanks, SourceBlanks, TargetBlanks, SourceAndTargetBlanks };
 
-    babelwires::MapValue getTestChordTypeMap(const babelwires::TypeSystem& typeSystem, Mode mode = Mode::NoBlanks) {
+    babelwires::MapValue getTestChordMap(const babelwires::TypeSystem& typeSystem, Mode mode = Mode::NoBlanks) {
         const seqwires::ChordType& chordTypeEnum = typeSystem.getEntryByType<seqwires::ChordType>();
-
-        babelwires::MapValue chordTypeMap;
-        chordTypeMap.setSourceTypeRef(seqwires::getMapChordFunctionChordTypeRef());
-        chordTypeMap.setTargetTypeRef(seqwires::getMapChordFunctionChordTypeRef());
-
-        {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionChordTypeRef(),
-                                                             seqwires::getMapChordFunctionChordTypeRef());
-
-            babelwires::EnumValue chordTypeSourceValue;
-            chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
-
-            babelwires::EnumValue chordTypeTargetValue;
-            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
-
-            chordTypeMaplet.setSourceValue(chordTypeSourceValue);
-            chordTypeMaplet.setTargetValue(chordTypeTargetValue);
-
-            chordTypeMap.emplaceBack(chordTypeMaplet.clone());
-        }
-        if ((mode == Mode::TargetBlanks) || (mode == Mode::SourceAndTargetBlanks)) {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionChordTypeRef(),
-                                                             seqwires::getMapChordFunctionChordTypeRef());
-
-            babelwires::EnumValue chordTypeSourceValue;
-            chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
-
-            babelwires::EnumValue chordTypeTargetValue;
-            chordTypeTargetValue.set(babelwires::AddBlankToEnum::getBlankValue());
-
-            chordTypeMaplet.setSourceValue(chordTypeSourceValue);
-            chordTypeMaplet.setTargetValue(chordTypeTargetValue);
-
-            chordTypeMap.emplaceBack(chordTypeMaplet.clone());
-        }
-        if ((mode == Mode::SourceBlanks) || (mode == Mode::SourceAndTargetBlanks)) {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionChordTypeRef(),
-                                                             seqwires::getMapChordFunctionChordTypeRef());
-
-            babelwires::EnumValue chordTypeSourceValue;
-            chordTypeSourceValue.set(babelwires::AddBlankToEnum::getBlankValue());
-
-            babelwires::EnumValue chordTypeTargetValue;
-            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
-
-            chordTypeMaplet.setSourceValue(chordTypeSourceValue);
-            chordTypeMaplet.setTargetValue(chordTypeTargetValue);
-
-            chordTypeMap.emplaceBack(chordTypeMaplet.clone());
-        }
-        chordTypeMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
-        return chordTypeMap;
-    }
-
-    babelwires::MapValue getTestPitchClassMap(const babelwires::TypeSystem& typeSystem, Mode mode = Mode::NoBlanks) {
         const seqwires::PitchClass& pitchClassEnum =
             typeSystem.getEntryByType<seqwires::PitchClass>().is<seqwires::PitchClass>();
 
-        babelwires::MapValue pitchClassMap;
-        pitchClassMap.setSourceTypeRef(seqwires::getMapChordFunctionPitchClassRef());
-        pitchClassMap.setTargetTypeRef(seqwires::getMapChordFunctionPitchClassRef());
+        babelwires::MapValue chordMap;
+        chordMap.setSourceTypeRef(seqwires::getMapChordFunctionSourceTypeRef());
+        chordMap.setTargetTypeRef(seqwires::getMapChordFunctionTargetTypeRef());
 
         {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionPitchClassRef(),
-                                                             seqwires::getMapChordFunctionPitchClassRef());
+            babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
+                                                         seqwires::getMapChordFunctionTargetTypeRef());
 
             babelwires::EnumValue pitchClassSourceValue;
             pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
 
+            babelwires::EnumValue chordTypeSourceValue;
+            chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
+
+            babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
+
             babelwires::EnumValue pitchClassTargetValue;
             pitchClassTargetValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
 
-            chordTypeMaplet.setSourceValue(pitchClassSourceValue);
-            chordTypeMaplet.setTargetValue(pitchClassTargetValue);
+            babelwires::EnumValue chordTypeTargetValue;
+            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
 
-            pitchClassMap.emplaceBack(chordTypeMaplet.clone());
+            babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+
+            chordMaplet.setSourceValue(sourceValue);
+            chordMaplet.setTargetValue(targetValue);
+
+            chordMap.emplaceBack(chordMaplet.clone());
         }
         if ((mode == Mode::TargetBlanks) || (mode == Mode::SourceAndTargetBlanks)) {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionPitchClassRef(),
-                                                             seqwires::getMapChordFunctionPitchClassRef());
+            babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
+                                                         seqwires::getMapChordFunctionTargetTypeRef());
 
             babelwires::EnumValue pitchClassSourceValue;
             pitchClassSourceValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Gsh));
 
-            babelwires::EnumValue pitchClassTargetValue;
-            pitchClassTargetValue.set(babelwires::AddBlankToEnum::getBlankValue());
+            babelwires::EnumValue chordTypeSourceValue;
+            chordTypeSourceValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
 
-            chordTypeMaplet.setSourceValue(pitchClassSourceValue);
-            chordTypeMaplet.setTargetValue(pitchClassTargetValue);
+            babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
-            pitchClassMap.emplaceBack(chordTypeMaplet.clone());
+            babelwires::EnumValue targetValue;
+            targetValue.set(seqwires::NoChord::getNoChordValue());
+
+            chordMaplet.setSourceValue(sourceValue);
+            chordMaplet.setTargetValue(targetValue);
+
+            chordMap.emplaceBack(chordMaplet.clone());
         }
         if ((mode == Mode::SourceBlanks) || (mode == Mode::SourceAndTargetBlanks)) {
-            babelwires::OneToOneMapEntryData chordTypeMaplet(typeSystem, seqwires::getMapChordFunctionPitchClassRef(),
-                                                             seqwires::getMapChordFunctionPitchClassRef());
+            babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
+                                                         seqwires::getMapChordFunctionTargetTypeRef());
 
-            babelwires::EnumValue pitchClassSourceValue;
-            pitchClassSourceValue.set(babelwires::AddBlankToEnum::getBlankValue());
+            babelwires::EnumValue sourceValue;
+            sourceValue.set(seqwires::NoChord::getNoChordValue());
 
             babelwires::EnumValue pitchClassTargetValue;
             pitchClassTargetValue.set(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
 
-            chordTypeMaplet.setSourceValue(pitchClassSourceValue);
-            chordTypeMaplet.setTargetValue(pitchClassTargetValue);
+            babelwires::EnumValue chordTypeTargetValue;
+            chordTypeTargetValue.set(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
 
-            pitchClassMap.emplaceBack(chordTypeMaplet.clone());
+            babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+
+            chordMaplet.setSourceValue(sourceValue);
+            chordMaplet.setTargetValue(targetValue);
+
+            chordMap.emplaceBack(chordMaplet.clone());
         }
+        {
+            babelwires::AllToOneFallbackMapEntryData chordMaplet(typeSystem,
+                                                                 seqwires::getMapChordFunctionTargetTypeRef());
 
-        pitchClassMap.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
-        return pitchClassMap;
+            babelwires::EnumValue wildcardValue;
+            wildcardValue.set(babelwires::getWildcardMatchId());
+
+            babelwires::TupleValue targetValue({wildcardValue, wildcardValue});
+
+            chordMaplet.setTargetValue(targetValue);
+
+            chordMap.emplaceBack(chordMaplet.clone());
+        }
+        return chordMap;
     }
 
     seqwires::Track getTestInputTrack() {
@@ -143,8 +119,8 @@ namespace {
 
         testUtils::addChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
                                babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                              {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::M},
-                              {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M6},
+                              {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m},
+                              {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
                               {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                               {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                              track);
@@ -160,34 +136,34 @@ namespace {
         if (mode == Mode::NoBlanks) {
             testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M6},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
+                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
                                   outputTrack);
         } else if (mode == Mode::TargetBlanks) {
             testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m7,
+                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m,
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
                                   outputTrack);
         } else if (mode == Mode::SourceBlanks) {
             testUtils::testChords({{seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M6},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
+                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                                   outputTrack);
         } else if (mode == Mode::SourceAndTargetBlanks) {
             testUtils::testChords({{seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::M},
-                                   {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
-                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                   {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m,
+                                    babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                                   outputTrack);
@@ -195,25 +171,25 @@ namespace {
     }
 } // namespace
 
-TEST(ChordMapProcessorTest, simpleFunction) {
-    testUtils::TestLog log;
+class ChordMapProcessorTest : public testing::TestWithParam<Mode> {};
 
-    babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry<seqwires::ChordType>();
-    typeSystem.addEntry<seqwires::PitchClass>();
-    typeSystem.addTypeConstructor<babelwires::AddBlankToEnum>();
+TEST_P(ChordMapProcessorTest, simpleFunction) {
+    testUtils::TestEnvironment testEnvironment;
+    seqwires::registerLib(testEnvironment.m_projectContext);
 
-    for (auto mode :
-         std::array<Mode, 4>{Mode::NoBlanks, Mode::TargetBlanks, Mode::SourceBlanks, Mode::SourceAndTargetBlanks}) {
-        babelwires::MapValue chordTypeMap = getTestChordTypeMap(typeSystem, mode);
-        babelwires::MapValue pitchClassMap = getTestPitchClassMap(typeSystem, mode);
+    const Mode mode = GetParam();
+    babelwires::MapValue chordMap = getTestChordMap(testEnvironment.m_typeSystem, mode);
 
-        seqwires::Track inputTrack = getTestInputTrack();
-        seqwires::Track outputTrack = seqwires::mapChordsFunction(typeSystem, inputTrack, chordTypeMap, pitchClassMap);
-        testOutputTrack(outputTrack, mode);
-    }
+    seqwires::Track inputTrack = getTestInputTrack();
+    seqwires::Track outputTrack = seqwires::mapChordsFunction(testEnvironment.m_typeSystem, inputTrack, chordMap);
+    testOutputTrack(outputTrack, mode);
 }
 
+INSTANTIATE_TEST_SUITE_P(ChordMapProcessorTest, ChordMapProcessorTest,
+                         testing::Values(Mode::NoBlanks, Mode::SourceBlanks, Mode::TargetBlanks,
+                                         Mode::SourceAndTargetBlanks));
+
+/*
 TEST(ChordMapProcessorTest, processor) {
     testUtils::TestEnvironment testEnvironment;
     seqwires::registerLib(testEnvironment.m_projectContext);
@@ -239,8 +215,7 @@ TEST(ChordMapProcessorTest, processor) {
             .is<babelwires::ValueTreeNode>();
 
     babelwires::ArrayInstanceImpl<babelwires::ValueTreeNode, seqwires::TrackType> inArray(inputArray);
-    const babelwires::ArrayInstanceImpl<const babelwires::ValueTreeNode, seqwires::TrackType> outArray(
-        outputArray);
+    const babelwires::ArrayInstanceImpl<const babelwires::ValueTreeNode, seqwires::TrackType> outArray(outputArray);
 
     seqwires::ChordMapProcessorInput::Instance in(input);
 

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -40,22 +40,39 @@ namespace {
         babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
                                                      seqwires::getMapChordFunctionTargetTypeRef());
         {
+            {
+                babelwires::EnumValue pitchClassSourceValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
+                babelwires::EnumValue chordTypeSourceValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
+                babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
-            babelwires::EnumValue pitchClassSourceValue(
-                pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
-            babelwires::EnumValue chordTypeSourceValue(
-                chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
-            babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
+                babelwires::EnumValue pitchClassTargetValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
+                babelwires::EnumValue chordTypeTargetValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
+                babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
-            babelwires::EnumValue pitchClassTargetValue(
-                pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
-            babelwires::EnumValue chordTypeTargetValue(
-                chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
-            babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+                chordMaplet.setSourceValue(sourceValue);
+                chordMaplet.setTargetValue(targetValue);
+                chordMap.emplaceBack(chordMaplet.clone());
+            }
+            if (wildcardMode == WildcardMode::Wildcards) {
+                babelwires::EnumValue wildcardValue(babelwires::getWildcardId());
+                babelwires::EnumValue chordTypeSourceValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M7s11));
+                babelwires::TupleValue sourceValue({wildcardValue, chordTypeSourceValue});
 
-            chordMaplet.setSourceValue(sourceValue);
-            chordMaplet.setTargetValue(targetValue);
-            chordMap.emplaceBack(chordMaplet.clone());
+                babelwires::EnumValue pitchClassTargetValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::B));
+                babelwires::EnumValue chordTypeTargetValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
+                babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
+
+                chordMaplet.setSourceValue(sourceValue);
+                chordMaplet.setTargetValue(targetValue);
+                chordMap.emplaceBack(chordMaplet.clone());
+            }
         }
         if (sourceMode == SourceMode::SilenceToChord) {
             {
@@ -126,17 +143,18 @@ namespace {
                               {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                               {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                              {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
+                              {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m},
+                              {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
                              track);
 
-        track.setDuration(babelwires::Rational(10, 2));
+        track.setDuration(babelwires::Rational(11, 2));
 
         return track;
     }
 
     void testOutputTrack(const seqwires::Track& outputTrack, SourceMode sourceMode, TargetMode targetMode,
                          WildcardMode wildcardMode) {
-        EXPECT_EQ(outputTrack.getDuration(), babelwires::Rational(10, 2));
+        EXPECT_EQ(outputTrack.getDuration(), babelwires::Rational(11, 2));
 
         if (wildcardMode == WildcardMode::NoWildcards) {
             if ((sourceMode == SourceMode::ChordToChord) && (targetMode == TargetMode::ChordToChord)) {
@@ -148,7 +166,8 @@ namespace {
                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                       {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::ChordToChord) && (targetMode == TargetMode::ChordToSilence)) {
                 testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
@@ -159,7 +178,8 @@ namespace {
                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                       {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToChord)) {
                 testUtils::testChords(
@@ -172,6 +192,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToSilence)) {
@@ -185,6 +206,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::M7s11},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             }
@@ -198,7 +220,8 @@ namespace {
                                        {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                       {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::ChordToChord) && (targetMode == TargetMode::ChordToSilence)) {
                 testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
@@ -208,7 +231,8 @@ namespace {
                                         babelwires::Rational(1, 2), babelwires::Rational(1)},
                                        {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                         babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
-                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
+                                       {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                                       {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7}},
                                       outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToChord)) {
                 testUtils::testChords(
@@ -221,6 +245,7 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                     outputTrack);
             } else if ((sourceMode == SourceMode::SilenceToChord) && (targetMode == TargetMode::ChordToSilence)) {
@@ -233,7 +258,9 @@ namespace {
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
-                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
+                     {seqwires::PitchClass::Value::B, seqwires::ChordType::ChordType::Value::m7},
+                     {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
+                     },
                     outputTrack);
             }
         }

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -124,16 +124,18 @@ namespace {
                               {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m},
                               {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
                               {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
+                              {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
+                               babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                               {seqwires::PitchClass::Value::D, seqwires::ChordType::ChordType::Value::m}},
                              track);
 
-        track.setDuration(babelwires::Rational(7, 2));
+        track.setDuration(babelwires::Rational(9, 2));
 
         return track;
     }
 
     void testOutputTrack(const seqwires::Track& outputTrack, SourceMode sourceMode, TargetMode targetMode) {
-        EXPECT_EQ(outputTrack.getDuration(), babelwires::Rational(7, 2));
+        EXPECT_EQ(outputTrack.getDuration(), babelwires::Rational(9, 2));
 
         if ((sourceMode == SourceMode::ChordOnly) && (targetMode == TargetMode::ChordOnly)) {
             testUtils::testChords({{seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M,
@@ -141,6 +143,8 @@ namespace {
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
+                                   {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
+                                    babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
                                   outputTrack);
         } else if ((sourceMode == SourceMode::ChordOnly) && (targetMode == TargetMode::ChordToNoChord)) {
@@ -148,6 +152,8 @@ namespace {
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m,
+                                    babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
+                                   {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m,
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7}},
                                   outputTrack);
@@ -157,6 +163,8 @@ namespace {
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Gsh, seqwires::ChordType::ChordType::Value::M6},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m},
+                                   {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
+                                   {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                                   outputTrack);
@@ -166,6 +174,8 @@ namespace {
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m,
                                     babelwires::Rational(1, 2), babelwires::Rational(1, 2)},
+                                   {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
+                                   {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                                    {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                                    {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11}},
                                   outputTrack);
@@ -174,7 +184,6 @@ namespace {
 
     using TestData = std::tuple<SourceMode, TargetMode>;
 } // namespace
-
 
 class ChordMapProcessorTest : public testing::TestWithParam<TestData> {};
 
@@ -190,12 +199,11 @@ TEST_P(ChordMapProcessorTest, simpleFunction) {
     testOutputTrack(outputTrack, sourceMode, targetMode);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ChordMapProcessorTest, ChordMapProcessorTest,
-    testing::Values(TestData{SourceMode::ChordOnly, TargetMode::ChordOnly},
-                    TestData{SourceMode::NoChordToChord, TargetMode::ChordOnly},
-                    TestData{SourceMode::ChordOnly, TargetMode::ChordToNoChord},
-                    TestData{SourceMode::NoChordToChord, TargetMode::ChordToNoChord}));
+INSTANTIATE_TEST_SUITE_P(ChordMapProcessorTest, ChordMapProcessorTest,
+                         testing::Values(TestData{SourceMode::ChordOnly, TargetMode::ChordOnly},
+                                         TestData{SourceMode::NoChordToChord, TargetMode::ChordOnly},
+                                         TestData{SourceMode::ChordOnly, TargetMode::ChordToNoChord},
+                                         TestData{SourceMode::NoChordToChord, TargetMode::ChordToNoChord}));
 
 /*
 TEST(ChordMapProcessorTest, processor) {

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -291,7 +291,6 @@ INSTANTIATE_TEST_SUITE_P(
                     TestData{SourceMode::SilenceToChord, TargetMode::ChordToChord, WildcardMode::Wildcards},
                     TestData{SourceMode::SilenceToChord, TargetMode::ChordToSilence, WildcardMode::Wildcards}));
 
-/*
 TEST(ChordMapProcessorTest, processor) {
     testUtils::TestEnvironment testEnvironment;
     seqwires::registerLib(testEnvironment.m_projectContext);
@@ -327,13 +326,11 @@ TEST(ChordMapProcessorTest, processor) {
     EXPECT_EQ(inArray.getEntry(0).get().getDuration(), 0);
     EXPECT_EQ(outArray.getEntry(0).get().getDuration(), 0);
 
-    in.getTypMap()->setValue(getTestChordTypeMap(testEnvironment.m_typeSystem));
-    in.getRtMap()->setValue(getTestPitchClassMap(testEnvironment.m_typeSystem));
+    in.getChrdMp()->setValue(getTestChordMap(testEnvironment.m_typeSystem, SourceMode::ChordToChord, TargetMode::ChordToChord, WildcardMode::NoWildcards));
     inArray.getEntry(0).set(getTestInputTrack());
 
     processor.process(testEnvironment.m_log);
 
-    testOutputTrack(outArray.getEntry(0).get());
+    testOutputTrack(outArray.getEntry(0).get(), SourceMode::ChordToChord, TargetMode::ChordToChord, WildcardMode::NoWildcards);
 }
 
-*/

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -20,6 +20,7 @@
 #include <Tests/TestUtils/seqTestUtils.hpp>
 #include <Tests/TestUtils/testLog.hpp>
 
+/*
 namespace {
     enum class Mode { NoBlanks, SourceBlanks, TargetBlanks, SourceAndTargetBlanks };
 
@@ -257,3 +258,5 @@ TEST(ChordMapProcessorTest, processor) {
 
     testOutputTrack(outArray.getEntry(0).get());
 }
+
+*/

--- a/Tests/SeqWiresLib/chordMapProcessorTest.cpp
+++ b/Tests/SeqWiresLib/chordMapProcessorTest.cpp
@@ -36,45 +36,48 @@ namespace {
         chordMap.setSourceTypeRef(seqwires::getMapChordFunctionSourceTypeRef());
         chordMap.setTargetTypeRef(seqwires::getMapChordFunctionTargetTypeRef());
 
+        // This object gets re-used.
+        babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
+                                                     seqwires::getMapChordFunctionTargetTypeRef());
         {
-            babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
-                                                         seqwires::getMapChordFunctionTargetTypeRef());
 
-            babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
-            babelwires::EnumValue chordTypeSourceValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
+            babelwires::EnumValue pitchClassSourceValue(
+                pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::D));
+            babelwires::EnumValue chordTypeSourceValue(
+                chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m));
             babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
-            babelwires::EnumValue pitchClassTargetValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
-            babelwires::EnumValue chordTypeTargetValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
+            babelwires::EnumValue pitchClassTargetValue(
+                pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::A));
+            babelwires::EnumValue chordTypeTargetValue(
+                chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7));
             babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
             chordMaplet.setSourceValue(sourceValue);
             chordMaplet.setTargetValue(targetValue);
-
             chordMap.emplaceBack(chordMaplet.clone());
         }
         if (sourceMode == SourceMode::SilenceToChord) {
-            babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
-                                                         seqwires::getMapChordFunctionTargetTypeRef());
+            {
+                babelwires::EnumValue sourceValue(seqwires::NoChord::getNoChordValue());
 
-            babelwires::EnumValue sourceValue(seqwires::NoChord::getNoChordValue());
+                babelwires::EnumValue pitchClassTargetValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
+                babelwires::EnumValue chordTypeTargetValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
+                babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
 
-            babelwires::EnumValue pitchClassTargetValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Fsh));
-            babelwires::EnumValue chordTypeTargetValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::m7_11));
-            babelwires::TupleValue targetValue({pitchClassTargetValue, chordTypeTargetValue});
-
-            chordMaplet.setSourceValue(sourceValue);
-            chordMaplet.setTargetValue(targetValue);
-
-            chordMap.emplaceBack(chordMaplet.clone());
+                chordMaplet.setSourceValue(sourceValue);
+                chordMaplet.setTargetValue(targetValue);
+                chordMap.emplaceBack(chordMaplet.clone());
+            }
         }
         if (targetMode == TargetMode::ChordToSilence) {
             {
-                babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
-                                                             seqwires::getMapChordFunctionTargetTypeRef());
-
-                babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Gsh));
-                babelwires::EnumValue chordTypeSourceValue(chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
+                babelwires::EnumValue pitchClassSourceValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Gsh));
+                babelwires::EnumValue chordTypeSourceValue(
+                    chordTypeEnum.getIdentifierFromValue(seqwires::ChordType::Value::M6));
                 babelwires::TupleValue sourceValue({pitchClassSourceValue, chordTypeSourceValue});
 
                 babelwires::EnumValue targetValue;
@@ -82,14 +85,11 @@ namespace {
 
                 chordMaplet.setSourceValue(sourceValue);
                 chordMaplet.setTargetValue(targetValue);
-
                 chordMap.emplaceBack(chordMaplet.clone());
             }
             if (wildcardMode == WildcardMode::Wildcards) {
-                babelwires::OneToOneMapEntryData chordMaplet(typeSystem, seqwires::getMapChordFunctionSourceTypeRef(),
-                                                             seqwires::getMapChordFunctionTargetTypeRef());
-
-                babelwires::EnumValue pitchClassSourceValue(pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Dsh));
+                babelwires::EnumValue pitchClassSourceValue(
+                    pitchClassEnum.getIdentifierFromValue(seqwires::PitchClass::Value::Dsh));
                 babelwires::EnumValue wildcardValue(babelwires::getWildcardId());
                 babelwires::TupleValue sourceValue({pitchClassSourceValue, wildcardValue});
 
@@ -98,7 +98,6 @@ namespace {
 
                 chordMaplet.setSourceValue(sourceValue);
                 chordMaplet.setTargetValue(targetValue);
-
                 chordMap.emplaceBack(chordMaplet.clone());
             }
         }
@@ -230,7 +229,7 @@ namespace {
                      {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::M},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
                      {seqwires::PitchClass::Value::C, seqwires::ChordType::ChordType::Value::m,
-                        babelwires::Rational(1, 2), babelwires::Rational(1)},
+                      babelwires::Rational(1, 2), babelwires::Rational(1)},
                      {seqwires::PitchClass::Value::Fsh, seqwires::ChordType::ChordType::Value::m7_11},
                      {seqwires::PitchClass::Value::E, seqwires::ChordType::ChordType::Value::m},
                      {seqwires::PitchClass::Value::A, seqwires::ChordType::ChordType::Value::m7},
@@ -259,16 +258,14 @@ TEST_P(ChordMapProcessorTest, simpleFunction) {
 
 INSTANTIATE_TEST_SUITE_P(
     ChordMapProcessorTest, ChordMapProcessorTest,
-    testing::Values(
-                    TestData{SourceMode::ChordToChord, TargetMode::ChordToChord, WildcardMode::NoWildcards},
+    testing::Values(TestData{SourceMode::ChordToChord, TargetMode::ChordToChord, WildcardMode::NoWildcards},
                     TestData{SourceMode::ChordToChord, TargetMode::ChordToSilence, WildcardMode::NoWildcards},
                     TestData{SourceMode::SilenceToChord, TargetMode::ChordToChord, WildcardMode::NoWildcards},
                     TestData{SourceMode::SilenceToChord, TargetMode::ChordToSilence, WildcardMode::NoWildcards},
                     TestData{SourceMode::ChordToChord, TargetMode::ChordToChord, WildcardMode::Wildcards},
                     TestData{SourceMode::ChordToChord, TargetMode::ChordToSilence, WildcardMode::Wildcards},
                     TestData{SourceMode::SilenceToChord, TargetMode::ChordToChord, WildcardMode::Wildcards},
-                    TestData{SourceMode::SilenceToChord, TargetMode::ChordToSilence, WildcardMode::Wildcards}
-                ));
+                    TestData{SourceMode::SilenceToChord, TargetMode::ChordToSilence, WildcardMode::Wildcards}));
 
 /*
 TEST(ChordMapProcessorTest, processor) {

--- a/Tests/TestUtils/seqTestUtils.hpp
+++ b/Tests/TestUtils/seqTestUtils.hpp
@@ -20,7 +20,7 @@ namespace testUtils {
     struct NoteInfo {
         seqwires::Pitch m_pitch;
         seqwires::ModelDuration m_noteOnTime = 0;
-        seqwires::ModelDuration m_noteOffTime = babelwires::Rational(1, 4);;
+        seqwires::ModelDuration m_noteOffTime = babelwires::Rational(1, 4);
     };
 
     /// Add notes as described to the track. Each has quaternote duration.
@@ -31,6 +31,7 @@ namespace testUtils {
 
     struct ChordInfo {
         seqwires::Chord m_chord;
+        // TODO Different order to NoteInfo: Very confusing!!!
         seqwires::ModelDuration m_chordOffTime = babelwires::Rational(1, 2);
         seqwires::ModelDuration m_chordOnTime = 0;
     };


### PR DESCRIPTION
The ChordMapProcessor in SeqWires was constrained by the type system. It could map chordTypes to chordTypes and pitchClasses to pitchClasses, but couldn't map specific combinations to each other. 

With tuple types, the ChordMapProcess can now express this kind of relationship.

Future work:
* ChordMap in the MapEditor are not beautiful. In particular, the type expressions are quite ugly. Type Aliases might be one way to fix this.
* Per-component wildcard handling is handled by the ChordMap itself. This seems awkward since maps have their own built-in wildcard handling (the fallback system), but that only works at the top level. The wildcard handling for tuples could probably be genalized so that types can be easily augmented with wildcards and the corresponding map handling is (mostly) provided by the framework.