### PR TITLE
Improvements to TrackEvent class

### DIFF
--- a/MusicLib/Functions/monophonicSubtracksFunction.cpp
+++ b/MusicLib/Functions/monophonicSubtracksFunction.cpp
@@ -40,8 +40,6 @@ namespace {
 
     using PitchSet = std::set<bw_music::TrackEvent::GroupKey::GroupValue>;
 
-    const bw_music::TrackEvent::GroupKey::Category c_noteCategory = bw_music::NoteEvent::s_noteEventCategory;
-
     void moveEventToOtherTrack(bw_music::ModelDuration& timeSinceLastEventOther, bw_music::TrackEventHolder& event,
                                TrackBuilders& result) {
         event->setTimeSinceLastEvent(timeSinceLastEventOther);
@@ -87,7 +85,7 @@ namespace {
         int trackToUse = -1;
         bool shouldEvict = false;
         const auto& groupInfo = event->getGroupingInfo();
-        assert(groupInfo.m_groupKey.m_category == c_noteCategory);
+        assert(groupInfo.m_groupKey.m_category == bw_music::NoteEvent::getNoteEventCategory());
         for (int i = 0; i < trackInfos.size(); ++i) {
             auto& t = trackInfos[i];
             if (t.m_activeValue == groupInfo.m_groupKey.m_groupValue) {
@@ -191,7 +189,7 @@ babelwires::ResultT<bw_music::MonophonicSubtracksResult> bw_music::getMonophonic
         }
 
         const TrackEvent::GroupingInfo groupInfo = event.getGroupingInfo();
-        if (groupInfo.m_groupKey.m_category == c_noteCategory) {
+        if (groupInfo.m_groupKey.m_category == bw_music::NoteEvent::getNoteEventCategory()) {
             NoteEventInfo& noteInfo = noteEventsNow.emplace_back();
             noteInfo.m_event = event;
             noteInfo.m_originalIndex = noteEventsNow.size() - 1;

--- a/MusicLib/Functions/monophonicSubtracksFunction.cpp
+++ b/MusicLib/Functions/monophonicSubtracksFunction.cpp
@@ -28,7 +28,7 @@ namespace {
 
     struct TrackInfo {
         bw_music::ModelDuration m_timeSinceLastEvent;
-        bw_music::TrackEvent::GroupingInfo::GroupValue m_activeValue = bw_music::TrackEvent::GroupingInfo::c_notAValue;
+        bw_music::TrackEvent::GroupKey::GroupValue m_activeValue = bw_music::TrackEvent::GroupKey::c_notAValue;
     };
 
     struct NoteEventInfo {
@@ -38,9 +38,9 @@ namespace {
         int m_originalIndex;
     };
 
-    using PitchSet = std::set<bw_music::TrackEvent::GroupingInfo::GroupValue>;
+    using PitchSet = std::set<bw_music::TrackEvent::GroupKey::GroupValue>;
 
-    const bw_music::TrackEvent::GroupingInfo::Category c_noteCategory = bw_music::NoteEvent::s_noteEventCategory;
+    const bw_music::TrackEvent::GroupKey::Category c_noteCategory = bw_music::NoteEvent::s_noteEventCategory;
 
     void moveEventToOtherTrack(bw_music::ModelDuration& timeSinceLastEventOther, bw_music::TrackEventHolder& event,
                                TrackBuilders& result) {
@@ -55,12 +55,12 @@ namespace {
         auto& t = trackInfos[trackToUse];
         noteEvent.m_event->setTimeSinceLastEvent(t.m_timeSinceLastEvent);
         result.m_noteTracks[trackToUse].addEvent(noteEvent.m_event.release());
-        if (groupInfo.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::StartOfGroup) {
+        if (groupInfo.m_groupRole == bw_music::TrackEvent::GroupRole::StartOfGroup) {
             // Too strong?
-            assert(t.m_activeValue == bw_music::TrackEvent::GroupingInfo::c_notAValue);
-            t.m_activeValue = groupInfo.m_groupValue;
-        } else if (groupInfo.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::EndOfGroup) {
-            t.m_activeValue = bw_music::TrackEvent::GroupingInfo::c_notAValue;
+            assert(t.m_activeValue == bw_music::TrackEvent::GroupKey::c_notAValue);
+            t.m_activeValue = groupInfo.m_groupKey.m_groupValue;
+        } else if (groupInfo.m_groupRole == bw_music::TrackEvent::GroupRole::EndOfGroup) {
+            t.m_activeValue = bw_music::TrackEvent::GroupKey::c_notAValue;
         }
         t.m_timeSinceLastEvent = 0;
     }
@@ -72,7 +72,7 @@ namespace {
         assert((evictedPitches.find(pitchToEvict) == evictedPitches.end()) && "Evicting an already evicted pitch");
         evictedPitches.insert(pitchToEvict);
         result.m_noteTracks[trackToUse].addEvent(bw_music::NoteOffEvent{t.m_timeSinceLastEvent, pitchToEvict});
-        t.m_activeValue = bw_music::TrackEvent::GroupingInfo::c_notAValue;
+        t.m_activeValue = bw_music::TrackEvent::GroupKey::c_notAValue;
         t.m_timeSinceLastEvent = 0;
     }
 
@@ -87,14 +87,14 @@ namespace {
         int trackToUse = -1;
         bool shouldEvict = false;
         const auto& groupInfo = event->getGroupingInfo();
-        assert(groupInfo.m_category == c_noteCategory);
+        assert(groupInfo.m_groupKey.m_category == c_noteCategory);
         for (int i = 0; i < trackInfos.size(); ++i) {
             auto& t = trackInfos[i];
-            if (t.m_activeValue == groupInfo.m_groupValue) {
+            if (t.m_activeValue == groupInfo.m_groupKey.m_groupValue) {
                 trackToUse = i;
                 break;
-            } else if ((trackToUse == -1) && (t.m_activeValue == bw_music::TrackEvent::GroupingInfo::c_notAValue) &&
-                        (groupInfo.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::StartOfGroup)) {
+            } else if ((trackToUse == -1) && (t.m_activeValue == bw_music::TrackEvent::GroupKey::c_notAValue) &&
+                        (groupInfo.m_groupRole == bw_music::TrackEvent::GroupRole::StartOfGroup)) {
                 trackToUse = i;
             }
         }
@@ -103,7 +103,7 @@ namespace {
                                                                      : std::numeric_limits<bw_music::Pitch>::min();
             for (int i = 0; i < trackInfos.size(); ++i) {
                 auto& t = trackInfos[i];
-                if (((groupInfo.m_groupValue > t.m_activeValue) == preferHigherPitches) &&
+                if (((groupInfo.m_groupKey.m_groupValue > t.m_activeValue) == preferHigherPitches) &&
                     ((t.m_activeValue < bestEvictablePitch) == preferHigherPitches)) {
                     trackToUse = i;
                     bestEvictablePitch = t.m_activeValue;
@@ -123,18 +123,18 @@ namespace {
         const auto lessThan = [preferHigherPitches](NoteEventInfo& a, NoteEventInfo& b) {
             const auto& groupInfoA = a.m_event->getGroupingInfo();
             const auto& groupInfoB = b.m_event->getGroupingInfo();
-            if ((groupInfoA.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::EndOfGroup) &&
-                (groupInfoB.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::StartOfGroup)) {
+            if ((groupInfoA.m_groupRole == bw_music::TrackEvent::GroupRole::EndOfGroup) &&
+                (groupInfoB.m_groupRole == bw_music::TrackEvent::GroupRole::StartOfGroup)) {
                 return true;
             }
-            if ((groupInfoA.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::StartOfGroup) &&
-                (groupInfoB.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::EndOfGroup)) {
+            if ((groupInfoA.m_groupRole == bw_music::TrackEvent::GroupRole::StartOfGroup) &&
+                (groupInfoB.m_groupRole == bw_music::TrackEvent::GroupRole::EndOfGroup)) {
                 return false;
             }
-            if (groupInfoA.m_groupValue > groupInfoB.m_groupValue) {
+            if (groupInfoA.m_groupKey.m_groupValue > groupInfoB.m_groupKey.m_groupValue) {
                 return preferHigherPitches;
             }
-            if (groupInfoA.m_groupValue < groupInfoB.m_groupValue) {
+            if (groupInfoA.m_groupKey.m_groupValue < groupInfoB.m_groupKey.m_groupValue) {
                 return !preferHigherPitches;
             }
             // Preserve the original order in other cases.
@@ -145,9 +145,9 @@ namespace {
 
         for (auto& noteEvent : noteEvents) {
             const bw_music::TrackEvent::GroupingInfo groupInfo = noteEvent.m_event->getGroupingInfo();
-            const auto it = evictedPitches.find(groupInfo.m_groupValue);
+            const auto it = evictedPitches.find(groupInfo.m_groupKey.m_groupValue);
             if (it != evictedPitches.end()) {
-                if (groupInfo.m_grouping == bw_music::TrackEvent::GroupingInfo::Grouping::EndOfGroup) {
+                if (groupInfo.m_groupRole == bw_music::TrackEvent::GroupRole::EndOfGroup) {
                     evictedPitches.erase(it);
                 } // else ignore this event.
             } else {
@@ -175,8 +175,6 @@ babelwires::ResultT<bw_music::MonophonicSubtracksResult> bw_music::getMonophonic
     builders.m_noteTracks.resize(numTracks);
     ModelDuration timeSinceLastEventOther;
 
-    using Group = std::tuple<TrackEvent::GroupingInfo::Category, TrackEvent::GroupingInfo::GroupValue>;
-
     std::vector<NoteEventInfo> noteEventsNow;
     PitchSet evictedPitches;
 
@@ -193,7 +191,7 @@ babelwires::ResultT<bw_music::MonophonicSubtracksResult> bw_music::getMonophonic
         }
 
         const TrackEvent::GroupingInfo groupInfo = event.getGroupingInfo();
-        if (groupInfo.m_category == c_noteCategory) {
+        if (groupInfo.m_groupKey.m_category == c_noteCategory) {
             NoteEventInfo& noteInfo = noteEventsNow.emplace_back();
             noteInfo.m_event = event;
             noteInfo.m_originalIndex = noteEventsNow.size() - 1;

--- a/MusicLib/Functions/percussionMapFunction.cpp
+++ b/MusicLib/Functions/percussionMapFunction.cpp
@@ -72,7 +72,7 @@ babelwires::ResultT<bw_music::Track> bw_music::mapPercussionFunction(const babel
 
     for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
         const TrackEvent::GroupingInfo info = it->getGroupingInfo();
-        if (info.m_groupKey.m_category == PercussionEvent::s_percussionEventCategory) {
+        if (info.m_groupKey.m_category == PercussionEvent::getPercussionEventCategory()) {
             TrackEventHolder holder(*it);
             PercussionEvent& percussionEvent = static_cast<PercussionEvent&>(*holder);
             babelwires::ShortId newInstrument = mapApplicator[percussionEvent.getInstrument()];

--- a/MusicLib/Functions/percussionMapFunction.cpp
+++ b/MusicLib/Functions/percussionMapFunction.cpp
@@ -72,7 +72,7 @@ babelwires::ResultT<bw_music::Track> bw_music::mapPercussionFunction(const babel
 
     for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
         const TrackEvent::GroupingInfo info = it->getGroupingInfo();
-        if (info.m_category == PercussionEvent::s_percussionEventCategory) {
+        if (info.m_groupKey.m_category == PercussionEvent::s_percussionEventCategory) {
             TrackEventHolder holder(*it);
             PercussionEvent& percussionEvent = static_cast<PercussionEvent&>(*holder);
             babelwires::ShortId newInstrument = mapApplicator[percussionEvent.getInstrument()];

--- a/MusicLib/Functions/quantizeFunction.cpp
+++ b/MusicLib/Functions/quantizeFunction.cpp
@@ -20,9 +20,6 @@ namespace {
 } // namespace
 
 babelwires::ResultT<bw_music::Track> bw_music::quantize(const Track& trackIn, ModelDuration beat) {
-
-    using Group = std::tuple<TrackEvent::GroupingInfo::Category, TrackEvent::GroupingInfo::GroupValue>;
-
     TrackBuilder track;
 
     ModelDuration currentTimeSinceLastEvent;

--- a/MusicLib/Functions/transposeFunction.cpp
+++ b/MusicLib/Functions/transposeFunction.cpp
@@ -7,6 +7,7 @@
  **/
 #include <MusicLib/Functions/transposeFunction.hpp>
 
+#include <MusicLib/Types/Track/TrackEvents/transposable.hpp>
 #include <MusicLib/Types/Track/trackBuilder.hpp>
 
 babelwires::ResultT<bw_music::Track> bw_music::transposeTrack(const Track& trackIn, int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {
@@ -18,15 +19,19 @@ babelwires::ResultT<bw_music::Track> bw_music::transposeTrack(const Track& track
     
     for (auto it = trackIn.begin(); it != trackIn.end(); ++it) {
         TrackEventHolder holder(*it);
-        if (holder->transpose(pitchOffset, outOfRangePolicy)) {
-            if (durationOfDroppedEvents > 0) {
-                holder->setTimeSinceLastEvent(holder->getTimeSinceLastEvent() + durationOfDroppedEvents);
-                durationOfDroppedEvents = 0;
+        if (auto* transposable = holder->tryInterface<Transposable>()) {
+            if (!transposable->transpose(pitchOffset, outOfRangePolicy)) {
+                durationOfDroppedEvents += holder->getTimeSinceLastEvent();
+                continue;
             }
-            trackOut.addEvent(holder.release());
-        } else {
-            durationOfDroppedEvents += holder->getTimeSinceLastEvent();
         }
+
+        if (durationOfDroppedEvents > 0) {
+            holder->setTimeSinceLastEvent(holder->getTimeSinceLastEvent() + durationOfDroppedEvents);
+            durationOfDroppedEvents = 0;
+        }
+
+        trackOut.addEvent(holder.release());
     }
 
     return trackOut.finishAndGetTrack(trackIn.getDuration());

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
@@ -14,7 +14,7 @@
 
 bw_music::TrackEvent::GroupKey::Category bw_music::ChordEvent::s_chordEventCategory = "Chords";
 
-void bw_music::ChordEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
+void bw_music::ChordOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = ChordOffEvent(timeSinceLastEvent);
 }
 

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
@@ -12,7 +12,7 @@
 
 #include <sstream>
 
-bw_music::TrackEvent::GroupingInfo::Category bw_music::ChordEvent::s_chordEventCategory = "Chords";
+bw_music::TrackEvent::GroupKey::Category bw_music::ChordEvent::s_chordEventCategory = "Chords";
 
 void bw_music::ChordEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = ChordOffEvent(timeSinceLastEvent);
@@ -23,7 +23,7 @@ std::size_t bw_music::ChordOnEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::ChordOnEvent::getGroupingInfo() const {
-    return {s_chordEventCategory, 0, GroupingInfo::Grouping::StartOfGroup};
+    return {s_chordEventCategory, 0, GroupRole::StartOfGroup};
 }
 
 bool bw_music::ChordOnEvent::transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {
@@ -39,7 +39,7 @@ std::size_t bw_music::ChordOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::ChordOffEvent::getGroupingInfo() const {
-    return {s_chordEventCategory, 0, GroupingInfo::Grouping::EndOfGroup};
+    return {s_chordEventCategory, 0, GroupRole::EndOfGroup};
 }
 
 bool bw_music::ChordOnEvent::doIsEqualTo(const TrackEvent& other) const {

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.cpp
@@ -1,34 +1,38 @@
 /**
  * ChordEvents describe musical chords.
- * 
+ *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <MusicLib/Types/Track/TrackEvents/chordEvents.hpp>
 
-
 #include <BaseLib/Hash/hash.hpp>
+#include <BaseLib/Identifiers/registeredIdentifier.hpp>
 
 #include <sstream>
 
-bw_music::TrackEvent::GroupKey::Category bw_music::ChordEvent::s_chordEventCategory = "Chords";
+bw_music::TrackEvent::GroupKey::Category bw_music::ChordEvent::getChordEventCategory() {
+    return BW_SHORT_ID("Chords", "Chords", "4f338e52-ac8e-422e-b3c5-143f84ccfcdd");
+}
 
 void bw_music::ChordOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = ChordOffEvent(timeSinceLastEvent);
 }
 
 std::size_t bw_music::ChordOnEvent::getHash() const {
-    return babelwires::hash::mixtureOf(static_cast<const char*>("ChordOn"), m_timeSinceLastEvent, m_chord.m_root, m_chord.m_chordType);
+    return babelwires::hash::mixtureOf(static_cast<const char*>("ChordOn"), m_timeSinceLastEvent, m_chord.m_root,
+                                       m_chord.m_chordType);
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::ChordOnEvent::getGroupingInfo() const {
-    return {s_chordEventCategory, 0, GroupRole::StartOfGroup};
+    return {getChordEventCategory(), 0, GroupRole::StartOfGroup};
 }
 
 bool bw_music::ChordOnEvent::transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {
     // Ignore the policy here, as chord roots are always mapped to within an octave.
-    const auto newPitchOpt = bw_music::transposePitch(static_cast<int>(m_chord.m_root), pitchOffset, TransposeOutOfRangePolicy::MapToNearestOctave, 0, 11);
+    const auto newPitchOpt = bw_music::transposePitch(static_cast<int>(m_chord.m_root), pitchOffset,
+                                                      TransposeOutOfRangePolicy::MapToNearestOctave, 0, 11);
     assert(newPitchOpt.has_value());
     m_chord.m_root = static_cast<PitchClass::Value>(newPitchOpt.value());
     return true;
@@ -39,7 +43,7 @@ std::size_t bw_music::ChordOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::ChordOffEvent::getGroupingInfo() const {
-    return {s_chordEventCategory, 0, GroupRole::EndOfGroup};
+    return {getChordEventCategory(), 0, GroupRole::EndOfGroup};
 }
 
 bool bw_music::ChordOnEvent::doIsEqualTo(const TrackEvent& other) const {

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
@@ -9,6 +9,7 @@
 
 #include <MusicLib/musicLibExport.hpp>
 
+#include <MusicLib/Types/Track/TrackEvents/startEventInterface.hpp>
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
 #include <MusicLib/Types/Track/TrackEvents/transposable.hpp>
 #include <MusicLib/chord.hpp>
@@ -25,19 +26,19 @@ namespace bw_music {
 
         static GroupKey::Category s_chordEventCategory;
 
-        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
     };
 
     /// Describes the start of a chord.
-    struct MUSICLIB_API ChordOnEvent : public ChordEvent, public Transposable {
+    struct MUSICLIB_API ChordOnEvent : public ChordEvent, public Transposable, public StartEventInterface {
         DOWNCASTABLE(ChordOnEvent, ChordEvent);
         STREAM_EVENT(ChordOnEvent);
-        QUERYABLE_INTERFACE_PROVIDER(ChordEvent, Transposable);
+        QUERYABLE_INTERFACE_PROVIDER(ChordEvent, Transposable, StartEventInterface);
         ChordOnEvent() = default;
         ChordOnEvent(ModelDuration timeSinceLastEvent, Chord chord)
             : ChordEvent(timeSinceLastEvent)
             , m_chord(chord) {}
 
+        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
         virtual std::size_t getHash() const override;
         virtual GroupingInfo getGroupingInfo() const override;
         virtual bool transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) override;

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
@@ -31,8 +31,8 @@ namespace bw_music {
     /// Describes the start of a chord.
     struct MUSICLIB_API ChordOnEvent : public ChordEvent, public Transposable {
         DOWNCASTABLE(ChordOnEvent, ChordEvent);
-        INTERFACE_QUERYABLE(ChordEvent, Transposable);
         STREAM_EVENT(ChordOnEvent);
+        QUERYABLE_INTERFACE_PROVIDER(ChordEvent, Transposable);
         ChordOnEvent() = default;
         ChordOnEvent(ModelDuration timeSinceLastEvent, Chord chord)
             : ChordEvent(timeSinceLastEvent)

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
@@ -24,7 +24,7 @@ namespace bw_music {
         ChordEvent(ModelDuration timeSinceLastEvent)
             : TrackEvent(timeSinceLastEvent) {}
 
-        static GroupKey::Category s_chordEventCategory;
+        static GroupKey::Category getChordEventCategory();
 
     };
 

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
@@ -10,6 +10,7 @@
 #include <MusicLib/musicLibExport.hpp>
 
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
+#include <MusicLib/Types/Track/TrackEvents/transposable.hpp>
 #include <MusicLib/chord.hpp>
 
 namespace bw_music {
@@ -28,8 +29,9 @@ namespace bw_music {
     };
 
     /// Describes the start of a chord.
-    struct MUSICLIB_API ChordOnEvent : public ChordEvent {
+    struct MUSICLIB_API ChordOnEvent : public ChordEvent, public Transposable {
         DOWNCASTABLE(ChordOnEvent, ChordEvent);
+        INTERFACE_QUERYABLE(ChordEvent, Transposable);
         STREAM_EVENT(ChordOnEvent);
         ChordOnEvent() = default;
         ChordOnEvent(ModelDuration timeSinceLastEvent, Chord chord)

--- a/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/chordEvents.hpp
@@ -22,7 +22,7 @@ namespace bw_music {
         ChordEvent(ModelDuration timeSinceLastEvent)
             : TrackEvent(timeSinceLastEvent) {}
 
-        static GroupingInfo::Category s_chordEventCategory;
+        static GroupKey::Category s_chordEventCategory;
 
         void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
     };

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
@@ -14,7 +14,7 @@
 
 bw_music::TrackEvent::GroupKey::Category bw_music::NoteEvent::s_noteEventCategory = "Notes";
 
-void bw_music::NoteEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
+void bw_music::NoteOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     // Create a NoteOffEvent with the same pitch.
     // Use the default NoteOffEvent velocity unless the NoteOnEvent's velocity is lower.
     dest = NoteOffEvent(timeSinceLastEvent, m_pitch, std::min(m_velocity, static_cast<Velocity>(NoteOffEvent::c_defaultVelocity)));

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
@@ -8,16 +8,20 @@
 #include <MusicLib/Types/Track/TrackEvents/noteEvents.hpp>
 
 #include <BaseLib/Hash/hash.hpp>
+#include <BaseLib/Identifiers/registeredIdentifier.hpp>
 
 #include <algorithm>
 #include <sstream>
 
-bw_music::TrackEvent::GroupKey::Category bw_music::NoteEvent::s_noteEventCategory = "Notes";
+bw_music::TrackEvent::GroupKey::Category bw_music::NoteEvent::getNoteEventCategory() {
+    return BW_SHORT_ID("Notes", "Notes", "b4303406-2c1d-477d-ae0e-7db718096c4d");
+}
 
 void bw_music::NoteOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     // Create a NoteOffEvent with the same pitch.
     // Use the default NoteOffEvent velocity unless the NoteOnEvent's velocity is lower.
-    dest = NoteOffEvent(timeSinceLastEvent, m_pitch, std::min(m_velocity, static_cast<Velocity>(NoteOffEvent::c_defaultVelocity)));
+    dest = NoteOffEvent(timeSinceLastEvent, m_pitch,
+                        std::min(m_velocity, static_cast<Velocity>(NoteOffEvent::c_defaultVelocity)));
 }
 
 bool bw_music::NoteEvent::transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {
@@ -35,7 +39,7 @@ std::size_t bw_music::NoteOnEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::NoteOnEvent::getGroupingInfo() const {
-    return {s_noteEventCategory, m_pitch, GroupRole::StartOfGroup};
+    return {getNoteEventCategory(), m_pitch, GroupRole::StartOfGroup};
 }
 
 std::size_t bw_music::NoteOffEvent::getHash() const {
@@ -43,11 +47,10 @@ std::size_t bw_music::NoteOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::NoteOffEvent::getGroupingInfo() const {
-    return {s_noteEventCategory, m_pitch, GroupRole::EndOfGroup};
+    return {getNoteEventCategory(), m_pitch, GroupRole::EndOfGroup};
 }
 
 bool bw_music::NoteEvent::doIsEqualTo(const TrackEvent& other) const {
     auto& otherNote = static_cast<const NoteEvent&>(other);
-    return TrackEvent::doIsEqualTo(other) && (m_pitch == otherNote.m_pitch) &&
-           (m_velocity == otherNote.m_velocity);
+    return TrackEvent::doIsEqualTo(other) && (m_pitch == otherNote.m_pitch) && (m_velocity == otherNote.m_velocity);
 }

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <sstream>
 
-bw_music::TrackEvent::GroupingInfo::Category bw_music::NoteEvent::s_noteEventCategory = "Notes";
+bw_music::TrackEvent::GroupKey::Category bw_music::NoteEvent::s_noteEventCategory = "Notes";
 
 void bw_music::NoteEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     // Create a NoteOffEvent with the same pitch.
@@ -35,7 +35,7 @@ std::size_t bw_music::NoteOnEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::NoteOnEvent::getGroupingInfo() const {
-    return {s_noteEventCategory, m_pitch, GroupingInfo::Grouping::StartOfGroup};
+    return {s_noteEventCategory, m_pitch, GroupRole::StartOfGroup};
 }
 
 std::size_t bw_music::NoteOffEvent::getHash() const {
@@ -43,7 +43,7 @@ std::size_t bw_music::NoteOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::NoteOffEvent::getGroupingInfo() const {
-    return {s_noteEventCategory, m_pitch, GroupingInfo::Grouping::EndOfGroup};
+    return {s_noteEventCategory, m_pitch, GroupRole::EndOfGroup};
 }
 
 bool bw_music::NoteEvent::doIsEqualTo(const TrackEvent& other) const {

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
@@ -9,6 +9,7 @@
 
 #include <MusicLib/musicLibExport.hpp>
 
+#include <MusicLib/Types/Track/TrackEvents/startEventInterface.hpp>
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
 #include <MusicLib/Types/Track/TrackEvents/transposable.hpp>
 
@@ -34,8 +35,6 @@ namespace bw_music {
         void setVelocity(Velocity velocity) { m_velocity = velocity; }
         Velocity getVelocity() const { return m_velocity; }
 
-        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
-
         Pitch m_pitch;
         Velocity m_velocity;
 
@@ -44,13 +43,15 @@ namespace bw_music {
     };
 
     /// The start of a musical note.
-    struct MUSICLIB_API NoteOnEvent : public NoteEvent {
+    struct MUSICLIB_API NoteOnEvent : public NoteEvent, public StartEventInterface {
         DOWNCASTABLE(NoteOnEvent, NoteEvent);
         STREAM_EVENT(NoteOnEvent);
+        QUERYABLE_INTERFACE_PROVIDER(NoteEvent, StartEventInterface);
         static constexpr const Velocity c_defaultVelocity = 127;
         NoteOnEvent(ModelDuration timeSinceLastEvent, Pitch pitch, Velocity velocity = c_defaultVelocity)
             : NoteEvent(timeSinceLastEvent, pitch, velocity) {}
 
+        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
         virtual std::size_t getHash() const override;
         virtual GroupingInfo getGroupingInfo() const override;
     };

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
@@ -24,7 +24,7 @@ namespace bw_music {
 
         virtual bool transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) override;
 
-        static GroupingInfo::Category s_noteEventCategory;
+        static GroupKey::Category s_noteEventCategory;
 
         void setPitch(Pitch pitch) { m_pitch = pitch; }
         Pitch getPitch() const { return m_pitch; }

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
@@ -27,7 +27,7 @@ namespace bw_music {
 
         virtual bool transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) override;
 
-        static GroupKey::Category s_noteEventCategory;
+        static GroupKey::Category getNoteEventCategory();
 
         void setPitch(Pitch pitch) { m_pitch = pitch; }
         Pitch getPitch() const { return m_pitch; }

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
@@ -17,8 +17,8 @@ namespace bw_music {
     /// Base type for note events.
     struct MUSICLIB_API NoteEvent : public TrackEvent, public Transposable {
         DOWNCASTABLE(NoteEvent, TrackEvent);
-        INTERFACE_QUERYABLE(TrackEvent, Transposable);
         STREAM_EVENT_ABSTRACT(NoteEvent);
+        QUERYABLE_INTERFACE_PROVIDER(TrackEvent, Transposable);
         NoteEvent(ModelDuration timeSinceLastEvent, Pitch pitch, Velocity velocity)
             : TrackEvent(timeSinceLastEvent)
             , m_pitch(pitch)

--- a/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/noteEvents.hpp
@@ -10,12 +10,14 @@
 #include <MusicLib/musicLibExport.hpp>
 
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
+#include <MusicLib/Types/Track/TrackEvents/transposable.hpp>
 
 namespace bw_music {
 
     /// Base type for note events.
-    struct MUSICLIB_API NoteEvent : public TrackEvent {
+    struct MUSICLIB_API NoteEvent : public TrackEvent, public Transposable {
         DOWNCASTABLE(NoteEvent, TrackEvent);
+        INTERFACE_QUERYABLE(TrackEvent, Transposable);
         STREAM_EVENT_ABSTRACT(NoteEvent);
         NoteEvent(ModelDuration timeSinceLastEvent, Pitch pitch, Velocity velocity)
             : TrackEvent(timeSinceLastEvent)
@@ -33,7 +35,7 @@ namespace bw_music {
         Velocity getVelocity() const { return m_velocity; }
 
         void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
-        
+
         Pitch m_pitch;
         Velocity m_velocity;
 

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
@@ -9,11 +9,14 @@
 
 
 #include <BaseLib/Hash/hash.hpp>
+#include <BaseLib/Identifiers/registeredIdentifier.hpp>
 
 #include <sstream>
 #include <algorithm>
 
-bw_music::TrackEvent::GroupKey::Category bw_music::PercussionEvent::s_percussionEventCategory = "Percussion";
+bw_music::TrackEvent::GroupKey::Category bw_music::PercussionEvent::getPercussionEventCategory() {
+    return BW_SHORT_ID("Perc", "Percussion", "ec551665-cb7f-404a-9219-401a7624a1f6");
+}
 
 void bw_music::PercussionOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = PercussionOffEvent(timeSinceLastEvent, m_instrument, m_velocity);
@@ -24,7 +27,7 @@ std::size_t bw_music::PercussionOnEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::PercussionOnEvent::getGroupingInfo() const {
-    return {s_percussionEventCategory, m_instrument.toCode(), GroupRole::StartOfGroup};
+    return {getPercussionEventCategory(), m_instrument.toCode(), GroupRole::StartOfGroup};
 }
 
 std::size_t bw_music::PercussionOffEvent::getHash() const {
@@ -32,7 +35,7 @@ std::size_t bw_music::PercussionOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::PercussionOffEvent::getGroupingInfo() const {
-    return {s_percussionEventCategory, m_instrument.toCode(), GroupRole::EndOfGroup};
+    return {getPercussionEventCategory(), m_instrument.toCode(), GroupRole::EndOfGroup};
 }
 
 bool bw_music::PercussionEvent::doIsEqualTo(const TrackEvent& other) const {

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
@@ -15,7 +15,7 @@
 
 bw_music::TrackEvent::GroupKey::Category bw_music::PercussionEvent::s_percussionEventCategory = "Percussion";
 
-void bw_music::PercussionEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
+void bw_music::PercussionOnEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = PercussionOffEvent(timeSinceLastEvent, m_instrument, m_velocity);
 }
 

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <algorithm>
 
-bw_music::TrackEvent::GroupingInfo::Category bw_music::PercussionEvent::s_percussionEventCategory = "Percussion";
+bw_music::TrackEvent::GroupKey::Category bw_music::PercussionEvent::s_percussionEventCategory = "Percussion";
 
 void bw_music::PercussionEvent::createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const {
     dest = PercussionOffEvent(timeSinceLastEvent, m_instrument, m_velocity);
@@ -24,7 +24,7 @@ std::size_t bw_music::PercussionOnEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::PercussionOnEvent::getGroupingInfo() const {
-    return {s_percussionEventCategory, m_instrument.toCode(), GroupingInfo::Grouping::StartOfGroup};
+    return {s_percussionEventCategory, m_instrument.toCode(), GroupRole::StartOfGroup};
 }
 
 std::size_t bw_music::PercussionOffEvent::getHash() const {
@@ -32,7 +32,7 @@ std::size_t bw_music::PercussionOffEvent::getHash() const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::PercussionOffEvent::getGroupingInfo() const {
-    return {s_percussionEventCategory, m_instrument.toCode(), GroupingInfo::Grouping::EndOfGroup};
+    return {s_percussionEventCategory, m_instrument.toCode(), GroupRole::EndOfGroup};
 }
 
 bool bw_music::PercussionEvent::doIsEqualTo(const TrackEvent& other) const {

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
@@ -19,7 +19,7 @@ namespace bw_music {
         DOWNCASTABLE(PercussionEvent, TrackEvent);
         STREAM_EVENT_ABSTRACT(PercussionEvent);
 
-        static GroupKey::Category s_percussionEventCategory;
+        static GroupKey::Category getPercussionEventCategory();
 
         void setInstrument(babelwires::ShortId instrument) { m_instrument = instrument; }
         babelwires::ShortId getInstrument() const { return m_instrument; }

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
@@ -18,7 +18,7 @@ namespace bw_music {
         DOWNCASTABLE(PercussionEvent, TrackEvent);
         STREAM_EVENT_ABSTRACT(PercussionEvent);
 
-        static GroupingInfo::Category s_percussionEventCategory;
+        static GroupKey::Category s_percussionEventCategory;
 
         void setInstrument(babelwires::ShortId instrument) { m_instrument = instrument; }
         babelwires::ShortId getInstrument() const { return m_instrument; }

--- a/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
+++ b/MusicLib/Types/Track/TrackEvents/percussionEvents.hpp
@@ -9,6 +9,7 @@
 
 #include <MusicLib/musicLibExport.hpp>
 
+#include <MusicLib/Types/Track/TrackEvents/startEventInterface.hpp>
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
 
 namespace bw_music {
@@ -26,8 +27,6 @@ namespace bw_music {
         void setVelocity(Velocity velocity) { m_velocity = velocity; }
         Velocity getVelocity() const { return m_velocity; }
 
-        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
-
       protected:
         PercussionEvent(ModelDuration timeSinceLastEvent, babelwires::ShortId instrument, Velocity velocity)
             : TrackEvent(timeSinceLastEvent)
@@ -42,11 +41,13 @@ namespace bw_music {
     };
 
     /// The start of a percussion event.
-    struct MUSICLIB_API PercussionOnEvent : public PercussionEvent {
+    struct MUSICLIB_API PercussionOnEvent : public PercussionEvent, public StartEventInterface {
         DOWNCASTABLE(PercussionOnEvent, PercussionEvent);
         STREAM_EVENT(PercussionOnEvent);
+        QUERYABLE_INTERFACE_PROVIDER(PercussionEvent, StartEventInterface);
         PercussionOnEvent(ModelDuration timeSinceLastEvent, babelwires::ShortId instrument, Velocity velocity = 127)
             : PercussionEvent(timeSinceLastEvent, instrument, velocity) {}
+        void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const override;
         virtual std::size_t getHash() const override;
         virtual GroupingInfo getGroupingInfo() const override;
     };

--- a/MusicLib/Types/Track/TrackEvents/startEventInterface.hpp
+++ b/MusicLib/Types/Track/TrackEvents/startEventInterface.hpp
@@ -1,0 +1,37 @@
+/**
+ * A queryable interface for track events that can create a matching end event.
+ *
+ * (C) 2026 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <MusicLib/musicLibExport.hpp>
+
+#include <BaseLib/BlockStream/streamEventHolder.hpp>
+#include <BaseLib/Utilities/queryableInterfaceProvider.hpp>
+
+#include <MusicLib/musicTypes.hpp>
+
+namespace bw_music {
+
+    class TrackEvent;
+    using TrackEventHolder = babelwires::StreamEventHolder<TrackEvent>;
+
+    /// Capability interface expected for all events at the start of a group. 
+    /// This allows start events to create matching end events when groups are truncated.
+    struct MUSICLIB_API StartEventInterface {
+        QUERYABLE_INTERFACE(StartEventInterface);
+        virtual ~StartEventInterface() = default;
+
+        /// Construct the matching end event for this event.
+        /// To correctly terminate truncated groups, a start event can be asked to construct a matching end event
+        /// of the same category and value.
+        // MAYBEDO Consider providing an iterator so the implementation can traverse the group.
+        // MAYBEDO If this returns nullptr for a start event, then it means the group cannot be truncated and the
+        // group should be removed.
+        virtual void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const = 0;
+    };
+
+} // namespace bw_music

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
@@ -27,7 +27,3 @@ bool bw_music::TrackEvent::operator!=(const TrackEvent& other) const {
 bw_music::TrackEvent::GroupingInfo bw_music::TrackEvent::getGroupingInfo() const {
     return {};
 }
-
-bool bw_music::TrackEvent::transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {
-    return true;
-}

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
@@ -8,8 +8,11 @@
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
 
 #include <BaseLib/Hash/hash.hpp>
+#include <BaseLib/Identifiers/registeredIdentifier.hpp>
 
-const char* bw_music::TrackEvent::GroupKey::s_genericCategory = "Generic";
+bw_music::TrackEvent::GroupKey::Category bw_music::TrackEvent::GroupKey::getGenericCategory() {
+    return BW_SHORT_ID("Genric", "Generic", "3908254a-c900-4426-96c4-34273eb8238d");
+}
 
 std::size_t bw_music::TrackEvent::getHash() const {
     // Since this is common to every event, there's no need to distinguish it from hashes of other events.
@@ -25,5 +28,5 @@ bool bw_music::TrackEvent::operator!=(const TrackEvent& other) const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::TrackEvent::getGroupingInfo() const {
-    return {};
+    return {{GroupKey::getGenericCategory()}, GroupRole::NotInGroup};
 }

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.cpp
@@ -9,7 +9,7 @@
 
 #include <BaseLib/Hash/hash.hpp>
 
-const char* bw_music::TrackEvent::EventGroup::s_genericCategory = "Generic";
+const char* bw_music::TrackEvent::GroupKey::s_genericCategory = "Generic";
 
 std::size_t bw_music::TrackEvent::getHash() const {
     // Since this is common to every event, there's no need to distinguish it from hashes of other events.
@@ -25,7 +25,7 @@ bool bw_music::TrackEvent::operator!=(const TrackEvent& other) const {
 }
 
 bw_music::TrackEvent::GroupingInfo bw_music::TrackEvent::getGroupingInfo() const {
-    return GroupingInfo();
+    return {};
 }
 
 bool bw_music::TrackEvent::transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy) {

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -32,8 +32,10 @@ namespace bw_music {
     class MUSICLIB_API TrackEvent : public babelwires::StreamEvent {
       public:
         DOWNCASTABLE(TrackEvent, babelwires::StreamEvent);
-        QUERYABLE_INTERFACE_PROVIDER_BASE();
         STREAM_EVENT_ABSTRACT(TrackEvent);
+        /// Events can support difference interfaces, queryable with tryInterface.
+        QUERYABLE_INTERFACE_PROVIDER_BASE();
+
         TrackEvent() = default;
         TrackEvent(ModelDuration timeSinceLastEvent)
             : m_timeSinceLastEvent(timeSinceLastEvent) {}
@@ -50,18 +52,12 @@ namespace bw_music {
         bool operator==(const TrackEvent& other) const;
         bool operator!=(const TrackEvent& other) const;
 
-        /// To correctly terminate truncated groups, a start event can be asked to construct a matching end event
-        /// of the same category and value. The default implementation asserts;
-        // MAYBEDO Consider providing an iterator so the implementation can traverse the group.
-        // MAYBEDO If this returns nullptr for a start event, then it means the group cannot be truncated and the
-        // group should be removed.
-        virtual void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const = 0;
-
         /// Describes the role an event plays in a group.
         enum class GroupRole : std::uint8_t {
             /// This is a stand-alone event.
             NotInGroup = 0,
             /// This event represents the start of a group.
+            /// Important: An event of this type is required to provide the StartEventInterface.
             StartOfGroup,
             /// This event represents the end of a group.
             EndOfGroup,

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -12,6 +12,7 @@
 #include <BaseLib/BlockStream/blockStream.hpp>
 #include <BaseLib/Cloning/cloneable.hpp>
 #include <BaseLib/Utilities/enumFlags.hpp>
+#include <BaseLib/Utilities/interfaceQueryable.hpp>
 
 #include <MusicLib/Utilities/musicUtilities.hpp>
 #include <MusicLib/musicTypes.hpp>
@@ -31,6 +32,7 @@ namespace bw_music {
     class MUSICLIB_API TrackEvent : public babelwires::StreamEvent {
       public:
         DOWNCASTABLE(TrackEvent, babelwires::StreamEvent);
+        INTERFACE_QUERYABLE_BASE();
         STREAM_EVENT_ABSTRACT(TrackEvent);
         TrackEvent() = default;
         TrackEvent(ModelDuration timeSinceLastEvent)
@@ -103,12 +105,6 @@ namespace bw_music {
 
         /// The default implementation returns values suitable for generic, ungrouped events.
         virtual GroupingInfo getGroupingInfo() const;
-
-        /// If it makes sense, transpose the pitch or pitches described by this event by the given number of semitones.
-        /// Return false if the event has become invalidated.
-        /// The default implementation does nothing and returns true.
-        virtual bool transpose(int pitchOffset,
-                               TransposeOutOfRangePolicy outOfRangePolicy = TransposeOutOfRangePolicy::Discard);
 
       protected:
         /// Subclasses should override this. They can assume that other is of their type.

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -11,6 +11,7 @@
 
 #include <BaseLib/BlockStream/blockStream.hpp>
 #include <BaseLib/Cloning/cloneable.hpp>
+#include <BaseLib/Identifiers/identifier.hpp>
 #include <BaseLib/Utilities/enumFlags.hpp>
 #include <BaseLib/Utilities/queryableInterfaceProvider.hpp>
 
@@ -69,15 +70,15 @@ namespace bw_music {
         /// For example, a noteOn event, a sequence of after-touch events, and a noteOff event,
         /// all of the same pitch.
         struct MUSICLIB_API GroupKey {
-            /// A pointer to a static string can act as a category.
-            using Category = const char*;
+            /// A resolved identifier gives a stable category identity and lookupable display name.
+            using Category = babelwires::ShortId;
 
             /// A category that can be used for events of no particular category.
-            static Category s_genericCategory;
+            static Category getGenericCategory();
 
             /// Categories are used to identify events which have the same grouping logic.
             /// E.g. notes or chords.
-            Category m_category = s_genericCategory;
+            Category m_category;
 
             /// A type that is (hopefully) big enough to distinguish all possible event groups of the same category.
             using GroupValue = std::uint64_t;
@@ -88,7 +89,11 @@ namespace bw_music {
             /// A value which is expected to agree for all events in the same group.
             GroupValue m_groupValue = c_notAValue;
 
-            auto operator<=>(const GroupKey&) const = default;
+            bool operator==(const GroupKey&) const = default;
+
+            bool operator<(const GroupKey& other) const {
+                return std::tie(m_category, m_groupValue) < std::tie(other.m_category, other.m_groupValue);
+            }
         };
 
         /// The GroupKey and GroupRole information for an event.

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -1,8 +1,8 @@
 /**
  * A TrackEvent is the base class of the events that occur in tracks.
- * 
+ *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -12,8 +12,9 @@
 #include <BaseLib/BlockStream/blockStream.hpp>
 #include <BaseLib/Cloning/cloneable.hpp>
 #include <BaseLib/Utilities/enumFlags.hpp>
-#include <MusicLib/musicTypes.hpp>
+
 #include <MusicLib/Utilities/musicUtilities.hpp>
+#include <MusicLib/musicTypes.hpp>
 
 #include <BaseLib/BlockStream/streamEventHolder.hpp>
 
@@ -32,7 +33,8 @@ namespace bw_music {
         DOWNCASTABLE(TrackEvent, babelwires::StreamEvent);
         STREAM_EVENT_ABSTRACT(TrackEvent);
         TrackEvent() = default;
-        TrackEvent(ModelDuration timeSinceLastEvent) : m_timeSinceLastEvent(timeSinceLastEvent) {}
+        TrackEvent(ModelDuration timeSinceLastEvent)
+            : m_timeSinceLastEvent(timeSinceLastEvent) {}
 
         /// The amount of time passed since the last event occurred.
         /// This can be 0 if the events are intended to occur at the same time.
@@ -53,10 +55,22 @@ namespace bw_music {
         // group should be removed.
         virtual void createEndEvent(TrackEventHolder& dest, ModelDuration timeSinceLastEvent) const = 0;
 
-        /// A value which describes how this event can participate in a group of similar events:
+        /// Describes the role an event plays in a group.
+        enum class GroupRole : std::uint8_t {
+            /// This is a stand-alone event.
+            NotInGroup = 0,
+            /// This event represents the start of a group.
+            StartOfGroup,
+            /// This event represents the end of a group.
+            EndOfGroup,
+            /// This event is (expected to be) inside a group.
+            EnclosedInGroup
+        };
+
+        /// Identifies a group of related events.
         /// For example, a noteOn event, a sequence of after-touch events, and a noteOff event,
         /// all of the same pitch.
-        struct MUSICLIB_API EventGroup {
+        struct MUSICLIB_API GroupKey {
             /// A pointer to a static string can act as a category.
             using Category = const char*;
 
@@ -67,26 +81,24 @@ namespace bw_music {
             /// E.g. notes or chords.
             Category m_category = s_genericCategory;
 
-            auto operator<=>(const EventGroup&) const = default;
+            /// A type that is (hopefully) big enough to distinguish all possible event groups of the same category.
+            using GroupValue = std::uint64_t;
+
+            /// The default value.
+            constexpr static GroupValue c_notAValue = -1;
 
             /// A value which is expected to agree for all events in the same group.
-            using GroupValue = std::uint64_t;
-            constexpr static GroupValue c_notAValue = -1;
             GroupValue m_groupValue = c_notAValue;
+
+            auto operator<=>(const GroupKey&) const = default;
         };
 
-        struct MUSICLIB_API GroupingInfo : EventGroup {
-            /// A value which determines the way in which this event belongs to a group.
-            enum class Grouping : std::uint8_t {
-                /// This is a stand-alone event.
-                NotInGroup = 0,
-                /// This event represents the start of a group.
-                StartOfGroup,
-                /// This event represents the end of a group.
-                EndOfGroup,
-                /// This event is (expected to be) inside a group.
-                EnclosedInGroup
-            } m_grouping = Grouping::NotInGroup;
+        /// The GroupKey and GroupRole information for an event.
+        struct MUSICLIB_API GroupingInfo {
+            GroupKey m_groupKey;
+            GroupRole m_groupRole = GroupRole::NotInGroup;
+
+            bool hasGroup() const { return m_groupRole != GroupRole::NotInGroup; }
         };
 
         /// The default implementation returns values suitable for generic, ungrouped events.
@@ -95,7 +107,8 @@ namespace bw_music {
         /// If it makes sense, transpose the pitch or pitches described by this event by the given number of semitones.
         /// Return false if the event has become invalidated.
         /// The default implementation does nothing and returns true.
-        virtual bool transpose(int pitchOffset, TransposeOutOfRangePolicy outOfRangePolicy = TransposeOutOfRangePolicy::Discard);
+        virtual bool transpose(int pitchOffset,
+                               TransposeOutOfRangePolicy outOfRangePolicy = TransposeOutOfRangePolicy::Discard);
 
       protected:
         /// Subclasses should override this. They can assume that other is of their type.

--- a/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
+++ b/MusicLib/Types/Track/TrackEvents/trackEvent.hpp
@@ -12,7 +12,7 @@
 #include <BaseLib/BlockStream/blockStream.hpp>
 #include <BaseLib/Cloning/cloneable.hpp>
 #include <BaseLib/Utilities/enumFlags.hpp>
-#include <BaseLib/Utilities/interfaceQueryable.hpp>
+#include <BaseLib/Utilities/queryableInterfaceProvider.hpp>
 
 #include <MusicLib/Utilities/musicUtilities.hpp>
 #include <MusicLib/musicTypes.hpp>
@@ -32,7 +32,7 @@ namespace bw_music {
     class MUSICLIB_API TrackEvent : public babelwires::StreamEvent {
       public:
         DOWNCASTABLE(TrackEvent, babelwires::StreamEvent);
-        INTERFACE_QUERYABLE_BASE();
+        QUERYABLE_INTERFACE_PROVIDER_BASE();
         STREAM_EVENT_ABSTRACT(TrackEvent);
         TrackEvent() = default;
         TrackEvent(ModelDuration timeSinceLastEvent)

--- a/MusicLib/Types/Track/TrackEvents/transposable.hpp
+++ b/MusicLib/Types/Track/TrackEvents/transposable.hpp
@@ -1,0 +1,29 @@
+/**
+ * A queryable interface for transposable track events.
+ *
+ * (C) 2026 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <MusicLib/musicLibExport.hpp>
+
+#include <MusicLib/Utilities/musicUtilities.hpp>
+
+#include <BaseLib/Utilities/interfaceQueryable.hpp>
+
+namespace bw_music {
+
+    /// Capability interface for track events whose pitches can be transposed.
+    struct MUSICLIB_API Transposable {
+        QUERYABLE_INTERFACE(Transposable);
+        virtual ~Transposable() = default;
+
+        /// If it makes sense, transpose the pitch or pitches described by this event by the given number of semitones.
+        /// Return false if the event has become invalidated.
+        virtual bool transpose(int pitchOffset,
+                               TransposeOutOfRangePolicy outOfRangePolicy = TransposeOutOfRangePolicy::Discard) = 0;
+    };
+
+} // namespace bw_music

--- a/MusicLib/Types/Track/TrackEvents/transposable.hpp
+++ b/MusicLib/Types/Track/TrackEvents/transposable.hpp
@@ -11,7 +11,7 @@
 
 #include <MusicLib/Utilities/musicUtilities.hpp>
 
-#include <BaseLib/Utilities/interfaceQueryable.hpp>
+#include <BaseLib/Utilities/queryableInterfaceProvider.hpp>
 
 namespace bw_music {
 

--- a/MusicLib/Types/Track/track.cpp
+++ b/MusicLib/Types/Track/track.cpp
@@ -81,6 +81,7 @@ void bw_music::Track::onNewEvent(const TrackEvent& event) {
     TrackEvent::GroupingInfo groupingInfo = event.getGroupingInfo();
     if ((groupingInfo.m_groupRole == TrackEvent::GroupRole::NotInGroup) ||
         (groupingInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup)) {
+        assert(groupingInfo.m_groupKey.m_category.getDiscriminator() != 0 && "Unresolved category identifier");
         ++m_numEventGroupsByCategory[groupingInfo.m_groupKey.m_category];
     }
 }
@@ -102,6 +103,6 @@ std::reverse_iterator<bw_music::Track::const_iterator> bw_music::Track::rend() c
 }
 
 
-const std::unordered_map<const char*, int>& bw_music::Track::getNumEventGroupsByCategory() const {
+const std::unordered_map<bw_music::TrackEvent::GroupKey::Category, int>& bw_music::Track::getNumEventGroupsByCategory() const {
     return m_numEventGroupsByCategory;
 }

--- a/MusicLib/Types/Track/track.cpp
+++ b/MusicLib/Types/Track/track.cpp
@@ -79,9 +79,9 @@ void bw_music::Track::onNewEvent(const TrackEvent& event) {
     m_totalEventDuration += event.getTimeSinceLastEvent();
     babelwires::hash::mixInto(m_eventHash, event.getHash());
     TrackEvent::GroupingInfo groupingInfo = event.getGroupingInfo();
-    if ((groupingInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::NotInGroup) ||
-        (groupingInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::StartOfGroup)) {
-        ++m_numEventGroupsByCategory[groupingInfo.m_category];
+    if ((groupingInfo.m_groupRole == TrackEvent::GroupRole::NotInGroup) ||
+        (groupingInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup)) {
+        ++m_numEventGroupsByCategory[groupingInfo.m_groupKey.m_category];
     }
 }
 

--- a/MusicLib/Types/Track/track.hpp
+++ b/MusicLib/Types/Track/track.hpp
@@ -61,7 +61,7 @@ namespace bw_music {
         std::size_t getHash() const override;
 
         /// Get a summary of the track contents, by category.
-        const std::unordered_map<const char*, int>& getNumEventGroupsByCategory() const;
+        const std::unordered_map<TrackEvent::GroupKey::Category, int>& getNumEventGroupsByCategory() const;
 
       private:
         friend TrackBuilder;
@@ -100,7 +100,7 @@ namespace bw_music {
         std::size_t m_eventHash = 0;
 
         /// A summary of information about the track.
-        std::unordered_map<const char*, int> m_numEventGroupsByCategory;
+        std::unordered_map<TrackEvent::GroupKey::Category, int> m_numEventGroupsByCategory;
     };
 
     /// This is only intended for testing tracks.

--- a/MusicLib/Types/Track/trackBuilder.cpp
+++ b/MusicLib/Types/Track/trackBuilder.cpp
@@ -7,6 +7,8 @@
  **/
 #include <MusicLib/Types/Track/trackBuilder.hpp>
 
+#include <MusicLib/Types/Track/TrackEvents/startEventInterface.hpp>
+
 bw_music::TrackBuilder::TrackBuilder() {}
 
 bw_music::TrackBuilder::TrackBuilder(Track startState)
@@ -167,7 +169,9 @@ void bw_music::TrackBuilder::endActiveGroups() {
             if (groupInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup) {
                 const auto activeGroupIt = m_activeGroups.find(groupInfo.m_groupKey);
                 if (activeGroupIt != m_activeGroups.end()) {
-                    it->createEndEvent(endEventsToAdd.emplace_back(), initialTime);
+                    const auto* endEventCreator = it->tryInterface<StartEventInterface>();
+                    assert(endEventCreator && "A start event did not provide StartEventInterface");
+                    endEventCreator->createEndEvent(endEventsToAdd.emplace_back(), initialTime);
                     assert(endEventsToAdd.back().hasEvent() && "A start event failed to create a corresponding end event");
                     assert(endEventsToAdd.back()->getGroupingInfo().m_groupRole == TrackEvent::GroupRole::EndOfGroup && "A start event created an event that was not an end event");
                     assert(endEventsToAdd.back()->getGroupingInfo().m_groupKey.m_category == groupInfo.m_groupKey.m_category && "A start event created an end event of the wrong category");

--- a/MusicLib/Types/Track/trackBuilder.cpp
+++ b/MusicLib/Types/Track/trackBuilder.cpp
@@ -14,16 +14,16 @@ bw_music::TrackBuilder::TrackBuilder(Track startState)
 
 bool bw_music::TrackBuilder::onNewEvent(const TrackEvent& event) {
     const TrackEvent::GroupingInfo groupInfo = event.getGroupingInfo();
-    if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::NotInGroup) {
+    if (groupInfo.m_groupRole == TrackEvent::GroupRole::NotInGroup) {
         return true;
     }
     if (!m_eventsAtCurrentTime.empty()) {
         m_eventsAtCurrentTime.emplace_back(event);
         return false;
     }
-    const auto it = m_activeGroups.find(groupInfo);
+    const auto it = m_activeGroups.find(groupInfo.m_groupKey);
     if (it == m_activeGroups.end()) {
-        if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::StartOfGroup) {
+        if (groupInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup) {
             m_eventsAtCurrentTime.emplace_back(event);
             // This is the necessarily the first event that will end up in m_eventsAtCurrentTime,
             // so the only one that could be carrying any time.
@@ -31,12 +31,12 @@ bool bw_music::TrackBuilder::onNewEvent(const TrackEvent& event) {
             return false;
         }
     } else {
-        if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::EndOfGroup) {
+        if (groupInfo.m_groupRole == TrackEvent::GroupRole::EndOfGroup) {
             m_activeGroups.erase(it);
             return true;
-        } else if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::EnclosedInGroup) {
+        } else if (groupInfo.m_groupRole == TrackEvent::GroupRole::EnclosedInGroup) {
             return true;
-        } else if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::StartOfGroup) {
+        } else if (groupInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup) {
             m_eventsAtCurrentTime.emplace_back(event);
             // This is the necessarily the first event that will end up in m_eventsAtCurrentTime,
             // so the only one that could be carrying any time.
@@ -96,15 +96,15 @@ void bw_music::TrackBuilder::processEventsAtCurrentTime(bool atEndOfTrack) {
     while (i < m_eventsAtCurrentTime.size()) {
         if (auto& event = m_eventsAtCurrentTime[i]) {
             const TrackEvent::GroupingInfo groupInfo = event->getGroupingInfo();
-            const auto activeGroupIt = m_activeGroups.find(groupInfo);
-            if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::StartOfGroup) {
+            const auto activeGroupIt = m_activeGroups.find(groupInfo.m_groupKey);
+            if (groupInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup) {
                 // See whether there's a matching end at the same time as the start.
                 unsigned int j = m_eventsAtCurrentTime.size() - 1;
                 while (j >= i + 1) {
                     if (auto& otherEvent = m_eventsAtCurrentTime[j]) {
                         const TrackEvent::GroupingInfo otherGroupInfo = otherEvent->getGroupingInfo();
-                        if (groupInfo == otherGroupInfo) {
-                            if (otherGroupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::EndOfGroup) {
+                        if (groupInfo.m_groupKey == otherGroupInfo.m_groupKey) {
+                            if (otherGroupInfo.m_groupRole == TrackEvent::GroupRole::EndOfGroup) {
                                 // Drop any matching events that were between the start and end.
                                 // They either belong to a zero length group or, in the reorder case, we don't know
                                 // which group they belong to.
@@ -112,7 +112,7 @@ void bw_music::TrackBuilder::processEventsAtCurrentTime(bool atEndOfTrack) {
                                     if (auto& eventInRange = m_eventsAtCurrentTime[k]) {
                                         const TrackEvent::GroupingInfo eventInRangeGroupInfo =
                                             eventInRange->getGroupingInfo();
-                                        if (eventInRangeGroupInfo == groupInfo) {
+                                        if (eventInRangeGroupInfo.m_groupKey == groupInfo.m_groupKey) {
                                             eventInRange.reset();
                                         }
                                     }
@@ -134,17 +134,17 @@ void bw_music::TrackBuilder::processEventsAtCurrentTime(bool atEndOfTrack) {
                     // Unmatched start: This is the normal case, but we still need to check for start in active group.
                     // Also, don't add start events if we're at the end of the track.
                     if ((activeGroupIt == m_activeGroups.end()) && !atEndOfTrack) {
-                        m_activeGroups.emplace(groupInfo);
+                        m_activeGroups.emplace(groupInfo.m_groupKey);
                         issueEvent(event.release());
                     }
                 }
-            } else if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::EndOfGroup) {
+            } else if (groupInfo.m_groupRole == TrackEvent::GroupRole::EndOfGroup) {
                 if (activeGroupIt != m_activeGroups.end()) {
                     m_activeGroups.erase(activeGroupIt);
                     issueEvent(event.release());
                 }
             } else {
-                assert(groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::EnclosedInGroup);
+                assert(groupInfo.m_groupRole == TrackEvent::GroupRole::EnclosedInGroup);
                 if (activeGroupIt != m_activeGroups.end()) {
                     issueEvent(event.release());
                 }
@@ -164,14 +164,14 @@ void bw_music::TrackBuilder::endActiveGroups() {
         auto it = m_track.rbegin();
         while (it != m_track.rend()) {
             const TrackEvent::GroupingInfo groupInfo = it->getGroupingInfo();
-            if (groupInfo.m_grouping == TrackEvent::GroupingInfo::Grouping::StartOfGroup) {
-                const auto activeGroupIt = m_activeGroups.find(groupInfo);
+            if (groupInfo.m_groupRole == TrackEvent::GroupRole::StartOfGroup) {
+                const auto activeGroupIt = m_activeGroups.find(groupInfo.m_groupKey);
                 if (activeGroupIt != m_activeGroups.end()) {
                     it->createEndEvent(endEventsToAdd.emplace_back(), initialTime);
                     assert(endEventsToAdd.back().hasEvent() && "A start event failed to create a corresponding end event");
-                    assert(endEventsToAdd.back()->getGroupingInfo().m_grouping == TrackEvent::GroupingInfo::Grouping::EndOfGroup && "A start event created an event that was not an end event");
-                    assert(endEventsToAdd.back()->getGroupingInfo().m_category == groupInfo.m_category && "A start event created an end event of the wrong category");
-                    assert(endEventsToAdd.back()->getGroupingInfo().m_groupValue == groupInfo.m_groupValue && "A start event created an end event of the wrong value");
+                    assert(endEventsToAdd.back()->getGroupingInfo().m_groupRole == TrackEvent::GroupRole::EndOfGroup && "A start event created an event that was not an end event");
+                    assert(endEventsToAdd.back()->getGroupingInfo().m_groupKey.m_category == groupInfo.m_groupKey.m_category && "A start event created an end event of the wrong category");
+                    assert(endEventsToAdd.back()->getGroupingInfo().m_groupKey.m_groupValue == groupInfo.m_groupKey.m_groupValue && "A start event created an end event of the wrong value");
                     initialTime = 0;
                     m_activeGroups.erase(activeGroupIt);
                     if (m_activeGroups.empty()) {

--- a/MusicLib/Types/Track/trackBuilder.hpp
+++ b/MusicLib/Types/Track/trackBuilder.hpp
@@ -50,7 +50,7 @@ namespace bw_music {
       private:
         Track m_track;
 
-        std::set<TrackEvent::EventGroup> m_activeGroups;
+        std::set<TrackEvent::GroupKey> m_activeGroups;
 
         /// When events are dropped, their time gets added to the next actual event.
         ModelDuration m_timeSinceLastEvent;

--- a/MusicLib/Utilities/trackValidator.cpp
+++ b/MusicLib/Utilities/trackValidator.cpp
@@ -10,7 +10,7 @@
 #include <map>
 
 bool bw_music::Detail::isTrackValidInternal(const bw_music::Track& track, bool assertIfInvalid = false) {
-    std::map<bw_music::TrackEvent::EventGroup, bw_music::ModelDuration> activeGroups;
+    std::map<bw_music::TrackEvent::GroupKey, bw_music::ModelDuration> activeGroups;
     for (const auto& e : track) {
         if (e.getTimeSinceLastEvent() > 0) {
             for (auto& times : activeGroups) {
@@ -18,19 +18,19 @@ bool bw_music::Detail::isTrackValidInternal(const bw_music::Track& track, bool a
             }
         }
         const auto groupInfo = e.getGroupingInfo();
-        auto activeGroupIt = activeGroups.find(groupInfo);
-        switch (groupInfo.m_grouping) {
-            case bw_music::TrackEvent::GroupingInfo::Grouping::StartOfGroup: {
+        auto activeGroupIt = activeGroups.find(groupInfo.m_groupKey);
+        switch (groupInfo.m_groupRole) {
+            case bw_music::TrackEvent::GroupRole::StartOfGroup: {
                 const bool noActiveGroup = (activeGroupIt == activeGroups.end());
                 assert((!assertIfInvalid || noActiveGroup) &&
                        "Encountered a start event when there was already a matching group.");
                 if (!noActiveGroup) {
                     return false;
                 }
-                activeGroups.emplace(groupInfo, 0);
+                activeGroups.emplace(groupInfo.m_groupKey, 0);
                 break;
             }
-            case bw_music::TrackEvent::GroupingInfo::Grouping::EnclosedInGroup: {
+            case bw_music::TrackEvent::GroupRole::EnclosedInGroup: {
                 const bool alreadyAGroup = (activeGroupIt != activeGroups.end());
                 assert((!assertIfInvalid || alreadyAGroup) &&
                        "Encountered an enclosed event when there was no matching group.");
@@ -39,7 +39,7 @@ bool bw_music::Detail::isTrackValidInternal(const bw_music::Track& track, bool a
                 }
                 break;
             }
-            case bw_music::TrackEvent::GroupingInfo::Grouping::EndOfGroup: {
+            case bw_music::TrackEvent::GroupRole::EndOfGroup: {
                 const bool alreadyAGroup = (activeGroupIt != activeGroups.end());
                 assert((!assertIfInvalid || alreadyAGroup) &&
                        "Encountered an end event when there was no matching group.");
@@ -55,7 +55,7 @@ bool bw_music::Detail::isTrackValidInternal(const bw_music::Track& track, bool a
                 activeGroups.erase(activeGroupIt);
                 break;
             }
-            case bw_music::TrackEvent::GroupingInfo::Grouping::NotInGroup:
+            case bw_music::TrackEvent::GroupRole::NotInGroup:
             default:
                 break;
         }

--- a/MusicLibUi/ValueModels/trackValueModel.cpp
+++ b/MusicLibUi/ValueModels/trackValueModel.cpp
@@ -9,6 +9,8 @@
 
 #include <MusicLib/Types/Track/track.hpp>
 
+#include <BaseLib/Identifiers/identifierRegistry.hpp>
+
 #include <QString>
 
 #include <cassert>
@@ -23,11 +25,13 @@ QString bw_musicUi::TrackValueModel::getTooltip() const {
     const bw_music::Track& track = getValue()->as<bw_music::Track>();
     const auto& numEventGroupsByCategory = track.getNumEventGroupsByCategory();
     if (!numEventGroupsByCategory.empty()) {
+        auto identifierRegistry = babelwires::IdentifierRegistry::read();
         QString summary;
         const char* delim = "";
         for (auto p : numEventGroupsByCategory) {
             summary += delim;
-            summary += QString("%1: %2").arg(p.first, QString::number(p.second));
+            summary += QString("%1: %2").arg(
+                QString::fromStdString(identifierRegistry->getName(p.first)), QString::number(p.second));
             delim = "\n";
         }
         return summary;

--- a/Plugins/Smf/Tests/percussionTests.cpp
+++ b/Plugins/Smf/Tests/percussionTests.cpp
@@ -92,8 +92,8 @@ TEST_P(SmfStandardPercussionTest, saveLoad) {
         const auto& track = track9->get();
 
         auto categoryMap = track.getNumEventGroupsByCategory();
-        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-        EXPECT_NE(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
+        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+        EXPECT_NE(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
 
         auto span = bw_music::iterateOver<bw_music::PercussionEvent>(track);
 
@@ -233,12 +233,12 @@ TEST_P(SmfTrackAllocationPercussionTest, trackAllocation) {
             auto categoryMap = track.getNumEventGroupsByCategory();
 
             if (testData.m_hasNotes[i]) {
-                ASSERT_NE(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-                EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory)->second, 1);
-                EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
+                ASSERT_NE(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+                EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory())->second, 1);
+                EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
             } else {
-                EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-                ASSERT_NE(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
+                EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+                ASSERT_NE(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
 
                 std::vector<babelwires::ShortId> instrumentsInTrack;
                 for (auto event : bw_music::iterateOver<bw_music::PercussionOnEvent>(track)) {

--- a/Plugins/Smf/Tests/testSuiteTests.cpp
+++ b/Plugins/Smf/Tests/testSuiteTests.cpp
@@ -73,8 +73,8 @@ TEST(SmfTestSuiteTest, cMajorScale) {
 
     const bw_music::Track& track = track0->get();
     const auto& categoryMap = track.getNumEventGroupsByCategory();
-    EXPECT_NE(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-    EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory)->second, 8);
+    EXPECT_NE(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+    EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory())->second, 8);
     EXPECT_EQ(track.getDuration(), babelwires::Rational(1, 4) * 8);
 
     testUtils::testSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65, 67, 69, 71, 72}, track);
@@ -320,8 +320,8 @@ TEST(SmfTestSuiteTest, testAllGMPercussion) {
     const bw_music::Track& track = track9->get();
 
     auto categoryMap = track.getNumEventGroupsByCategory();
-    EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-    EXPECT_NE(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
+    EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+    EXPECT_NE(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
 
     const auto& gm2StandardPercussionSet =
         testEnvironment.m_typeSystem.getRegisteredType<smf::GM2StandardPercussionSet>();
@@ -370,16 +370,16 @@ TEST(SmfTestSuiteTest, testGSDrumPartChange) {
         const bw_music::Track& track = track0->get();
 
         auto categoryMap = track.getNumEventGroupsByCategory();
-        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-        ASSERT_NE(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
-        EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory)->second, 4);
+        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+        ASSERT_NE(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
+        EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory())->second, 4);
     }
     {
         const bw_music::Track& track = track9->get();
 
         auto categoryMap = track.getNumEventGroupsByCategory();
-        EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::s_percussionEventCategory), categoryMap.end());
-        ASSERT_NE(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory), categoryMap.end());
-        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::s_noteEventCategory)->second, 4);
+        EXPECT_EQ(categoryMap.find(bw_music::PercussionEvent::getPercussionEventCategory()), categoryMap.end());
+        ASSERT_NE(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory()), categoryMap.end());
+        EXPECT_EQ(categoryMap.find(bw_music::NoteEvent::getNoteEventCategory())->second, 4);
     }
 }

--- a/Tests/MusicLib/concatenateProcessorTest.cpp
+++ b/Tests/MusicLib/concatenateProcessorTest.cpp
@@ -12,6 +12,8 @@
 #include <Tests/TestUtils/seqTestUtils.hpp>
 
 TEST(ConcatenateProcessorTest, appendFuncSimple) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilderA;
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackBuilderA);
     bw_music::Track trackA = trackBuilderA.finishAndGetTrack();
@@ -26,6 +28,8 @@ TEST(ConcatenateProcessorTest, appendFuncSimple) {
 }
 
 TEST(ConcatenateProcessorTest, appendFuncGaps) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilderA;
     const std::vector<testUtils::NoteInfo> noteInfosA{{60, babelwires::Rational(1, 4), 1},
                                                       {62, babelwires::Rational(1, 4)},

--- a/Tests/MusicLib/excerptProcessorTest.cpp
+++ b/Tests/MusicLib/excerptProcessorTest.cpp
@@ -15,6 +15,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(ExcerptProcessorTest, funcSimple) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65, 67, 69, 71, 72}, trackIn);
@@ -25,6 +27,8 @@ TEST(ExcerptProcessorTest, funcSimple) {
 }
 
 TEST(ExcerptProcessorTest, funcEmptyBefore) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
     bw_music::NoteOnEvent note(10, 64, 100);
     trackIn.addEvent(note);
@@ -36,6 +40,8 @@ TEST(ExcerptProcessorTest, funcEmptyBefore) {
 }
 
 TEST(ExcerptProcessorTest, funcEmptyAfter) {
+    testUtils::TestLog log;
+
     bw_music::Track trackIn;
 
     BW_ASSERT_RESULT_ASSIGN(auto trackOut, bw_music::getTrackExcerpt(trackIn, 2, 2));
@@ -45,6 +51,8 @@ TEST(ExcerptProcessorTest, funcEmptyAfter) {
 }
 
 TEST(ExcerptProcessorTest, funcEmptyBetween) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
     bw_music::NoteOnEvent noteOn(1, 64, 100);
     trackIn.addEvent(noteOn);
@@ -58,6 +66,8 @@ TEST(ExcerptProcessorTest, funcEmptyBetween) {
 }
 
 TEST(ExcerptProcessorTest, funcDropSpanningGroup) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
     bw_music::NoteOnEvent noteOn(1, 40, 100);
     trackIn.addEvent(noteOn);
@@ -71,6 +81,7 @@ TEST(ExcerptProcessorTest, funcDropSpanningGroup) {
 }
 
 TEST(ExcerptProcessorTest, funcDropInitialGroup) {
+    testUtils::TestLog log;
     bw_music::TrackBuilder trackIn;
 
     bw_music::NoteOnEvent noteOn(1, 40, 100);
@@ -89,6 +100,8 @@ TEST(ExcerptProcessorTest, funcDropInitialGroup) {
 }
 
 TEST(ExcerptProcessorTest, funcGaps) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65, 67, 69, 71, 72}, trackIn);

--- a/Tests/MusicLib/filteredTrackIteratorTest.cpp
+++ b/Tests/MusicLib/filteredTrackIteratorTest.cpp
@@ -4,9 +4,13 @@
 #include <MusicLib/Types/Track/trackBuilder.hpp>
 #include <MusicLib/Types/Track/TrackEvents/trackEvent.hpp>
 
+#include <Tests/TestUtils/testLog.hpp>
+
 #include <Tests/TestUtils/testTrackEvents.hpp>
 
 TEST(FilteredTrackIterator, Basic) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilder;
 
     for (int i = 0; i < 100; ++i) {

--- a/Tests/MusicLib/fingeredChordsProcessorTest.cpp
+++ b/Tests/MusicLib/fingeredChordsProcessorTest.cpp
@@ -14,6 +14,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(FingeredChordsTest, functionBasicNotesPolicy) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(0, 60));
     track.addEvent(bw_music::NoteOnEvent(0, 64));
@@ -52,6 +54,8 @@ TEST(FingeredChordsTest, functionBasicNotesPolicy) {
 }
 
 TEST(FingeredChordsTest, functionBasicHoldPolicy) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(0, 60));
     track.addEvent(bw_music::NoteOnEvent(0, 64));
@@ -90,6 +94,8 @@ TEST(FingeredChordsTest, functionBasicHoldPolicy) {
 }
 
 TEST(FingeredChordsTest, rootPitchClass) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
 
     for (int i = 0; i < 12 * 10; ++i) {
@@ -116,6 +122,8 @@ TEST(FingeredChordsTest, rootPitchClass) {
 }
 
 TEST(FingeredChordsTest, functionChordToChord) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(0, 60));
     track.addEvent(bw_music::NoteOnEvent(0, 64));
@@ -142,6 +150,8 @@ TEST(FingeredChordsTest, functionChordToChord) {
 
 // Only major and minor inversions are guaranteed to be recognized.
 TEST(FingeredChordsTest, majorInversions) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(0, 60));
     track.addEvent(bw_music::NoteOnEvent(0, 64));
@@ -181,6 +191,8 @@ TEST(FingeredChordsTest, majorInversions) {
 
 // Only major and minor inversions are guaranteed to be recognized.
 TEST(FingeredChordsTest, minorInversions) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(0, 60));
     track.addEvent(bw_music::NoteOnEvent(0, 63));
@@ -220,6 +232,7 @@ TEST(FingeredChordsTest, minorInversions) {
 
 // Yamaha-style fingered chords.
 TEST(FingeredChordsTest, schemeY) {
+    testUtils::TestLog log;
     using namespace bw_music;
 
     std::vector<std::vector<bw_music::Pitch>> pitches = {// C1+8
@@ -383,6 +396,7 @@ TEST(FingeredChordsTest, schemeY) {
 
 // Roland-style fingered chords.
 TEST(FingeredChordsTest, schemeR) {
+    testUtils::TestLog log;
     using namespace bw_music;
 
     std::vector<std::vector<bw_music::Pitch>> pitches = {// C

--- a/Tests/MusicLib/fitToChordFunctionTest.cpp
+++ b/Tests/MusicLib/fitToChordFunctionTest.cpp
@@ -76,6 +76,7 @@ class FitToChordFunctionTest : public ::testing::Test {
         EXPECT_EQ(it, track.end());
     };
 
+    testUtils::TestLog m_log;
     bw_music::Track m_cMajorChordTrack;
     bw_music::Track m_lowerLimitTrack;
     bw_music::Track m_upperLimitTrack;

--- a/Tests/MusicLib/getChordTypesProcessorTest.cpp
+++ b/Tests/MusicLib/getChordTypesProcessorTest.cpp
@@ -34,6 +34,8 @@ class GetChordTypesProcessorTest : public ::testing::Test {
         EXPECT_NE(chordTypes.find(bw_music::ChordType::Value::dim), chordTypes.end());
         EXPECT_NE(chordTypes.find(bw_music::ChordType::Value::aug), chordTypes.end());
     }
+
+    testUtils::TestLog m_log;
 };
 
 TEST_F(GetChordTypesProcessorTest, functionBasic) {

--- a/Tests/MusicLib/mergeProcessorTest.cpp
+++ b/Tests/MusicLib/mergeProcessorTest.cpp
@@ -14,6 +14,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(MergeProcessorTest, simpleFunction) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilderA;
     testUtils::addSimpleNotes({72, 74, 76, 77}, trackBuilderA);
     bw_music::Track trackA = trackBuilderA.finishAndGetTrack();
@@ -63,6 +65,8 @@ TEST(MergeProcessorTest, simpleFunction) {
 }
 
 TEST(MergeProcessorTest, functionOverlaps) {
+    testUtils::TestLog log;
+    
     bw_music::TrackBuilder trackBuilderA;
     testUtils::addSimpleNotes({72, 74, 76, 77}, trackBuilderA);
     bw_music::Track trackA = trackBuilderA.finishAndGetTrack();

--- a/Tests/MusicLib/monophonicNoteIteratorTest.cpp
+++ b/Tests/MusicLib/monophonicNoteIteratorTest.cpp
@@ -5,6 +5,8 @@
 
 #include <Tests/TestUtils/testTrackEvents.hpp>
 
+#include <Tests/TestUtils/testLog.hpp>
+
 namespace {
     bw_music::Track createTestTrack() {
         bw_music::TrackBuilder track;
@@ -70,6 +72,8 @@ namespace {
 } // namespace
 
 TEST(MonophonicNoteIterator, OnOffOnly) {
+    testUtils::TestLog log;
+
     bw_music::Track track = createTestTrack();
 
     auto [it, end] = bw_music::iterateOverMonotonicNotes(track, bw_music::MonophonicNoteIterator::OnOffOnly);

--- a/Tests/MusicLib/monophonicSubtracksProcessorTest.cpp
+++ b/Tests/MusicLib/monophonicSubtracksProcessorTest.cpp
@@ -103,6 +103,8 @@ namespace {
 } // namespace
 
 TEST(MonophonicSubtracksProcessorTest, simpleFunction) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getSamplePolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -121,6 +123,8 @@ TEST(MonophonicSubtracksProcessorTest, simpleFunction) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, FunctionLower) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getSamplePolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -139,6 +143,8 @@ TEST(MonophonicSubtracksProcessorTest, FunctionLower) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, redundantTracks) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getSamplePolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -159,6 +165,8 @@ TEST(MonophonicSubtracksProcessorTest, redundantTracks) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, eventToOther) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getSamplePolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -188,6 +196,8 @@ TEST(MonophonicSubtracksProcessorTest, eventToOther) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictOneTrack) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getStaggeredPolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -226,6 +236,8 @@ TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictOneTrack) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictTwoTracks) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getStaggeredPolyphonicTrack();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -270,6 +282,8 @@ TEST(MonophonicSubtracksProcessorTest, higherPitchesEvictTwoTracks) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, lowerPitchesEvictOneTrack) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getStaggeredPolyphonicTrack2();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,
@@ -308,6 +322,8 @@ TEST(MonophonicSubtracksProcessorTest, lowerPitchesEvictOneTrack) {
 }
 
 TEST(MonophonicSubtracksProcessorTest, lowerPitchesEvictTwoTracks) {
+    testUtils::TestLog log;
+
     bw_music::Track track = getStaggeredPolyphonicTrack2();
 
     BW_ASSERT_RESULT_ASSIGN(bw_music::MonophonicSubtracksResult result,

--- a/Tests/MusicLib/musicUtilitiesTest.cpp
+++ b/Tests/MusicLib/musicUtilitiesTest.cpp
@@ -4,7 +4,11 @@
 #include <MusicLib/Types/Track/TrackEvents/noteEvents.hpp>
 #include <MusicLib/Types/Track/trackBuilder.hpp>
 
+#include <Tests/TestUtils/testLog.hpp>
+
 TEST(MusicUtilitiesTest, GetMinimumDenominator) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     track.addEvent(bw_music::NoteOnEvent(babelwires::Rational(1, 4), 60, 100));
     track.addEvent(bw_music::NoteOffEvent(babelwires::Rational(1, 8), 60));
@@ -16,6 +20,8 @@ TEST(MusicUtilitiesTest, GetMinimumDenominator) {
 }
 
 TEST(MusicUtilitiesTest, TransposePitch) {
+    testUtils::TestLog log;
+
     using namespace bw_music;
 
     // Test transposing within range

--- a/Tests/MusicLib/quantizeProcessorTest.cpp
+++ b/Tests/MusicLib/quantizeProcessorTest.cpp
@@ -14,6 +14,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(QuantizeProcessorTest, funcSimple) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilderIn;
 
     testUtils::addNotes(
@@ -56,6 +58,8 @@ TEST(QuantizeProcessorTest, funcSimple) {
 }
 
 TEST(QuantizeProcessorTest, funcCollapsedGroup) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addNotes(

--- a/Tests/MusicLib/repeatProcessorTest.cpp
+++ b/Tests/MusicLib/repeatProcessorTest.cpp
@@ -15,6 +15,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(RepeatProcessorTest, funcSimpleZero) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);
@@ -26,6 +28,8 @@ TEST(RepeatProcessorTest, funcSimpleZero) {
 }
 
 TEST(RepeatProcessorTest, funcSimpleOnce) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);
@@ -36,6 +40,8 @@ TEST(RepeatProcessorTest, funcSimpleOnce) {
 }
 
 TEST(RepeatProcessorTest, funcSimpleTwice) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);

--- a/Tests/MusicLib/splitAtPitchProcessorTest.cpp
+++ b/Tests/MusicLib/splitAtPitchProcessorTest.cpp
@@ -16,6 +16,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(SplitAtPitchProcessorTest, monophonicSplit) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track;
     testUtils::addSimpleNotes({60, 62, 64, 65, 67, 69, 71, 72}, track);
 
@@ -43,6 +45,8 @@ TEST(SplitAtPitchProcessorTest, monophonicSplit) {
 }
 
 TEST(SplitAtPitchProcessorTest, aboveAndBelowSplit) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilder;
     trackBuilder.addEvent(bw_music::NoteOnEvent{0, 72});
     trackBuilder.addEvent(bw_music::NoteOnEvent{0, 48});

--- a/Tests/MusicLib/trackBuilderTest.cpp
+++ b/Tests/MusicLib/trackBuilderTest.cpp
@@ -20,7 +20,7 @@ namespace {
             , m_pitch(pitch) {}
 
         bw_music::TrackEvent::GroupingInfo getGroupingInfo() const override {
-            return {bw_music::NoteEvent::s_noteEventCategory, m_pitch,
+            return {bw_music::NoteEvent::getNoteEventCategory(), m_pitch,
                 bw_music::TrackEvent::GroupRole::EnclosedInGroup};
         }
         bw_music::Pitch m_pitch;
@@ -34,6 +34,8 @@ namespace {
 } // namespace
 
 TEST(TrackBuilderTest, validator_validSimple) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
 
     track.addEvent(bw_music::NoteOnEvent(0, 60));
@@ -49,6 +51,8 @@ TEST(TrackBuilderTest, validator_validSimple) {
 }
 
 TEST(TrackBuilderTest, validator_invalidSimpleZeroLengthNote) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
 
     track.addEvent(bw_music::NoteOnEvent(0, 60));
@@ -64,6 +68,8 @@ TEST(TrackBuilderTest, validator_invalidSimpleZeroLengthNote) {
 }
 
 TEST(TrackBuilderTest, validator_invalidSimpleEndEventOutsideGroup) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
 
     track.addEvent(bw_music::NoteOnEvent(0, 60));
@@ -80,6 +86,8 @@ TEST(TrackBuilderTest, validator_invalidSimpleEndEventOutsideGroup) {
 }
 
 TEST(TrackBuilderTest, validator_invalidStartEventInsideGroup) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
 
     track.addEvent(bw_music::NoteOnEvent(0, 60));
@@ -96,6 +104,8 @@ TEST(TrackBuilderTest, validator_invalidStartEventInsideGroup) {
 }
 
 TEST(TrackBuilderTest, validator_invalidUnterminatedGroup) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
 
     track.addEvent(bw_music::NoteOnEvent(0, 60));
@@ -112,6 +122,8 @@ TEST(TrackBuilderTest, validator_invalidUnterminatedGroup) {
 }
 
 TEST(TrackBuilderTest, builder_validSimple) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -138,6 +150,8 @@ TEST(TrackBuilderTest, builder_validSimple) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidSimpleZeroLengthNote) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -164,6 +178,8 @@ TEST(TrackBuilderTest, builder_InvalidSimpleZeroLengthNote) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidSimpleEndEventOutsideGroup) {
+    testUtils::TestLog log;
+    
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -191,6 +207,8 @@ TEST(TrackBuilderTest, builder_InvalidSimpleEndEventOutsideGroup) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidStartEventInsideGroup) {
+    testUtils::TestLog log;
+    
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -218,6 +236,8 @@ TEST(TrackBuilderTest, builder_InvalidStartEventInsideGroup) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidReordered) {
+    testUtils::TestLog log;
+    
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -244,6 +264,8 @@ TEST(TrackBuilderTest, builder_InvalidReordered) {
 }
 
 TEST(TrackBuilderTest, builder_invalidUnterminatedGroup) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -276,6 +298,8 @@ TEST(TrackBuilderTest, builder_invalidUnterminatedGroup) {
 }
 
 TEST(TrackBuilderTest, builder_invalidUnterminatedGroupWithDuration) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -308,6 +332,8 @@ TEST(TrackBuilderTest, builder_invalidUnterminatedGroupWithDuration) {
 }
 
 TEST(TrackBuilderTest, builder_invalidUnterminatedGroupWithDuration2) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -341,6 +367,8 @@ TEST(TrackBuilderTest, builder_invalidUnterminatedGroupWithDuration2) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidReorderedAndZeroLength) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     bw_music::TrackBuilder trackBuilder;
 
@@ -371,6 +399,8 @@ TEST(TrackBuilderTest, builder_InvalidReorderedAndZeroLength) {
 }
 
 TEST(TrackBuilderTest, builder_InvalidMixture) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack goodEvents;
     goodEvents.addEvent(bw_music::NoteOnEvent(0, 60));
     goodEvents.addEvent(TestEnclosedEvent(bw_music::ModelDuration(1, 8), 60));

--- a/Tests/MusicLib/trackBuilderTest.cpp
+++ b/Tests/MusicLib/trackBuilderTest.cpp
@@ -21,7 +21,7 @@ namespace {
 
         bw_music::TrackEvent::GroupingInfo getGroupingInfo() const override {
             return {bw_music::NoteEvent::s_noteEventCategory, m_pitch,
-                    bw_music::TrackEvent::GroupingInfo::Grouping::EnclosedInGroup};
+                bw_music::TrackEvent::GroupRole::EnclosedInGroup};
         }
         void createEndEvent(bw_music::TrackEventHolder& dest,
                             bw_music::ModelDuration timeSinceLastEvent) const override {}
@@ -433,7 +433,7 @@ TEST(TrackBuilderTest, builder_InvalidMixture) {
 
     unsigned int goodEventCount = 0;
     for (const auto& builtEvent : builtTrack) {
-        if (builtEvent.getGroupingInfo().m_groupValue < 72) {
+        if (builtEvent.getGroupingInfo().m_groupKey.m_groupValue < 72) {
             ++goodEventCount;
         }
     }

--- a/Tests/MusicLib/trackBuilderTest.cpp
+++ b/Tests/MusicLib/trackBuilderTest.cpp
@@ -23,8 +23,6 @@ namespace {
             return {bw_music::NoteEvent::s_noteEventCategory, m_pitch,
                 bw_music::TrackEvent::GroupRole::EnclosedInGroup};
         }
-        void createEndEvent(bw_music::TrackEventHolder& dest,
-                            bw_music::ModelDuration timeSinceLastEvent) const override {}
         bw_music::Pitch m_pitch;
 
       protected:

--- a/Tests/MusicLib/trackTest.cpp
+++ b/Tests/MusicLib/trackTest.cpp
@@ -7,8 +7,11 @@
 #include <Tests/TestUtils/seqTestUtils.hpp>
 #include <Tests/TestUtils/testTrackEvents.hpp>
 
+#include <Tests/TestUtils/testLog.hpp>
 
 TEST(Track, Simple) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack track;
     const size_t hashWhenEmpty = track.getHash();
 
@@ -41,6 +44,8 @@ TEST(Track, Simple) {
 }
 
 TEST(Track, BlocksAndAlignment) {
+    testUtils::TestLog log;
+
     EXPECT_NE(testUtils::TestTrackEvent(1).getSize(), testUtils::BigTestTrackEvent(1).getSize());
     EXPECT_NE(testUtils::TestTrackEvent(1).getAlignment(), testUtils::BigTestTrackEvent(1).getAlignment());
 
@@ -70,6 +75,8 @@ TEST(Track, BlocksAndAlignment) {
 }
 
 TEST(Track, PayloadTest) {
+    testUtils::TestLog log;
+
     int counter = 0;
 
     {
@@ -86,6 +93,8 @@ TEST(Track, PayloadTest) {
 }
 
 TEST(Track, equality) {
+    testUtils::TestLog log;
+
     bw_music::UnsafeTrack emptyTrack0;
     bw_music::UnsafeTrack emptyTrack1;
     bw_music::UnsafeTrack emptyTrackWithPositiveDuration;

--- a/Tests/MusicLib/trackTraverserTest.cpp
+++ b/Tests/MusicLib/trackTraverserTest.cpp
@@ -6,7 +6,11 @@
 
 #include <Tests/TestUtils/testTrackEvents.hpp>
 
+#include <Tests/TestUtils/testLog.hpp>
+
 TEST(TrackTraverser, leastUpperBoundDuration) {
+    testUtils::TestLog log;
+
     bw_music::Track track;
 
     track.setDuration(10);
@@ -27,6 +31,8 @@ TEST(TrackTraverser, leastUpperBoundDuration) {
 }
 
 TEST(TrackTraverser, greatestLowerBoundNextEvent) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder track1Builder;
     bw_music::TrackBuilder track2Builder;
     bw_music::TrackBuilder track3Builder;
@@ -53,6 +59,8 @@ TEST(TrackTraverser, greatestLowerBoundNextEvent) {
 }
 
 TEST(TrackTraverser, filteredIteration) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackBuilder;
 
     for (int i = 0; i < 10; ++i) {

--- a/Tests/MusicLib/transposeProcessorTest.cpp
+++ b/Tests/MusicLib/transposeProcessorTest.cpp
@@ -16,6 +16,8 @@
 #include <Tests/TestUtils/resultTestUtils.hpp>
 
 TEST(TransposeProcessorTest, funcSimpleZero) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);
@@ -26,6 +28,8 @@ TEST(TransposeProcessorTest, funcSimpleZero) {
 }
 
 TEST(TransposeProcessorTest, funcSimplePositive) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);
@@ -36,6 +40,8 @@ TEST(TransposeProcessorTest, funcSimplePositive) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleNegative) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{60, 62, 64, 65}, trackIn);
@@ -46,6 +52,8 @@ TEST(TransposeProcessorTest, funcSimpleNegative) {
 }
 
 TEST(TransposeProcessorTest, funcSimplePositiveLimitDiscard) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{120, 122, 124, 125, 124, 122, 120}, trackIn);
@@ -56,6 +64,8 @@ TEST(TransposeProcessorTest, funcSimplePositiveLimitDiscard) {
 }
 
 TEST(TransposeProcessorTest, funcSimplePositiveLimitMap) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{120, 122, 124, 125, 124, 122, 120}, trackIn);
@@ -67,6 +77,8 @@ TEST(TransposeProcessorTest, funcSimplePositiveLimitMap) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleNegativeLimitDiscard) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{17, 16, 14, 12, 14, 16, 17}, trackIn);
@@ -77,6 +89,8 @@ TEST(TransposeProcessorTest, funcSimpleNegativeLimitDiscard) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleNegativeLimitMap) {
+    testUtils::TestLog log;
+
     bw_music::TrackBuilder trackIn;
 
     testUtils::addSimpleNotes(std::vector<bw_music::Pitch>{17, 16, 14, 12, 14, 16, 17}, trackIn);
@@ -88,6 +102,8 @@ TEST(TransposeProcessorTest, funcSimpleNegativeLimitMap) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleChordsZero) {
+    testUtils::TestLog log;
+
     // Some random chords.
     auto trackIn = testUtils::getTrackOfChords({
         {bw_music::PitchClass::PitchClass::Value::C, bw_music::ChordType::ChordType::Value::M},
@@ -109,6 +125,8 @@ TEST(TransposeProcessorTest, funcSimpleChordsZero) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleChordsPositive) {
+    testUtils::TestLog log;
+
     // Some random chords.
     auto trackIn = testUtils::getTrackOfChords({
         {bw_music::PitchClass::PitchClass::Value::C, bw_music::ChordType::ChordType::Value::M},
@@ -130,6 +148,8 @@ TEST(TransposeProcessorTest, funcSimpleChordsPositive) {
 }
 
 TEST(TransposeProcessorTest, funcSimpleChordsNegative) {
+    testUtils::TestLog log;
+
     // Some random chords.
     auto trackIn = testUtils::getTrackOfChords({
         {bw_music::PitchClass::PitchClass::Value::C, bw_music::ChordType::ChordType::Value::M},

--- a/Tests/TestUtils/testTrackEvents.hpp
+++ b/Tests/TestUtils/testTrackEvents.hpp
@@ -8,7 +8,6 @@ namespace testUtils {
         TestTrackEvent(bw_music::ModelDuration d, int value = 1)
             : TrackEvent(d)
             , m_value(value) {}
-        void createEndEvent(bw_music::TrackEventHolder& dest, bw_music::ModelDuration timeSinceLastEvent) const override {}
 
         int m_value;
 
@@ -25,7 +24,6 @@ namespace testUtils {
         TestTrackEvent2(bw_music::ModelDuration d, float value)
             : TrackEvent(d)
             , m_value(value) {}
-        void createEndEvent(bw_music::TrackEventHolder& dest, bw_music::ModelDuration timeSinceLastEvent) const override {}
 
         float m_value;
 
@@ -41,7 +39,6 @@ namespace testUtils {
         STREAM_EVENT(BigTestTrackEvent);
         BigTestTrackEvent(bw_music::ModelDuration d)
             : TrackEvent(d) {}
-        void createEndEvent(bw_music::TrackEventHolder& dest, bw_music::ModelDuration timeSinceLastEvent) const override {}
 
         std::uint64_t m_big[5] = {};
     };
@@ -73,8 +70,6 @@ namespace testUtils {
             , m_payload(std::make_unique<Payload>(*other.m_payload)) {}
 
         ~TestTrackEventWithPayload() { m_payload.reset(); }
-
-        void createEndEvent(bw_music::TrackEventHolder& dest, bw_music::ModelDuration timeSinceLastEvent) const override {}
 
         std::unique_ptr<Payload> m_payload;
     };


### PR DESCRIPTION
The TrackEvent class has been improved as follows:
1. The EventGroup class has been decomposed into GroupKey and GroupRole.
2. The virtual functions transpose and createEndEvents are no longer in the base class. Instead, two queryable interfaces are used to make the same functionality available (Tranposable and StartEventInterface, respectively).
3. Category is now an identifier. 